### PR TITLE
Run build-dep before building go code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.10 as golang
 WORKDIR /go/src/github.com/IBM/portieris
 RUN mkdir -p /go/src/github.com/IBM/portieris
 COPY . ./
-# RUN make build-deps
+RUN make build-deps
 RUN CGO_ENABLED=0 GOOS=linux go build -a -o ./bin/trust ./cmd/trust
 
 FROM scratch


### PR DESCRIPTION
This will enable to run `make push` without failure, otherwise, docker build fails.