### PR TITLE
Fix typo

### DIFF
--- a/helm/portieris/README.md
+++ b/helm/portieris/README.md
@@ -60,5 +60,5 @@ For information about configuring security policies, and an explanation of the s
     ```
 2. Remove the chart.
     ```
-    helm delete --purge cise
+    helm delete --purge portieris
     ```


### PR DESCRIPTION
portieris is used as name everywhere in the readme so even in the helm delete portieris should be used.