### PR TITLE
Add commit ID question to issue template

### DIFF
--- a/ISSUE_TEMPLATE
+++ b/ISSUE_TEMPLATE
@@ -2,6 +2,8 @@
 
 <!-- Make sure to write a helpful title that accurately describes your problem! -->
 
+### What commit ID of Portieris did you experience the problem with?
+
 ### What went wrong?
 
 ### What should have happened differently?


### PR DESCRIPTION
Because we're getting people to build from master, users might be running on different code levels when they report a bug. This change asks reporters what code level they are using so that we can go back to investigate problems using the same code base that they're running from.