### PR TITLE
Update to latest image from Docker Hub

### DIFF
--- a/helm/portieris/values.yaml
+++ b/helm/portieris/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 3
 image:
   host: docker.io/ibmcom
   image: portieris
-  tag: 0.2.0
+  tag: 0.3.0
   pullPolicy: Always
 
 service:


### PR DESCRIPTION
Update the chart to point at the most recent build on Docker Hub: https://hub.docker.com/r/ibmcom/portieris/tags/

Fixes https://github.com/IBM/portieris/issues/27