### PR TITLE
Added support for applying image policy to initContainers

### DIFF
--- a/pkg/controller/notary/controller.go
+++ b/pkg/controller/notary/controller.go
@@ -84,97 +84,110 @@ func (c *Controller) mutatePodSpec(namespace, specPath string, pod corev1.PodSpe
 	patches := []types.JSONPatch{}
 
 	// Iterate over each container image specified
-containerLoop:
-	for containerIndex, container := range pod.Containers {
-		var policy *securityenforcementv1beta1.Policy
-		img, err := image.NewReference(container.Image)
-		if err != nil {
-			glog.Error(err)
-			a.StringToAdmissionResponse(fmt.Sprintf("Deny %q, invalid image name", container.Image))
-			continue containerLoop
+	for _, containerType := range []string{"initContainers", "containers"} {
+		var containers []corev1.Container
+		switch containerType {
+		case "initContainers":
+			containers = pod.InitContainers
+		case "containers":
+			containers = pod.Containers
+		default:
+			a.StringToAdmissionResponse("Unhandled container type")
+			return a.Flush()
 		}
 
-		glog.Infof("Container Image: %s   Namespace: %s", img.String(), namespace)
-		if policy, err = c.policyClient.GetPolicyToEnforce(namespace, img.String()); err != nil {
-			a.StringToAdmissionResponse(err.Error())
-			continue containerLoop
-		} else if policy == nil || !(policy.Trust.Enabled != nil && *policy.Trust.Enabled == true) {
-			a.SetAllowed()
-			continue containerLoop
-		}
-
-		// Trust is enforced
-		glog.Info("Trust is enforced")
-
-		// Make sure image sure there is a ImagePullSecret defined
-		// TODO: This prevents use of signed publically available images with publically available signing data
-		var registryToken string
-		if len(pod.ImagePullSecrets) == 0 {
-			a.StringToAdmissionResponse(fmt.Sprintf("Deny %q, no ImagePullSecret defined for %s", img.String(), img.GetHostname()))
-			continue containerLoop
-		}
-
-	secretLoop:
-		for _, secret := range pod.ImagePullSecrets {
-			registryToken, err = c.kubeClientsetWrapper.GetSecretToken(namespace, secret.Name, img.GetHostname())
+	containerLoop:
+		for containerIndex, container := range containers {
+			var policy *securityenforcementv1beta1.Policy
+			img, err := image.NewReference(container.Image)
 			if err != nil {
 				glog.Error(err)
-				continue secretLoop
-			}
-
-			notaryToken, err := c.cr.GetContentTrustToken(registryToken, img.NameWithoutTag(), img.GetRegistryURL())
-			if err != nil {
-				glog.Error(err)
-				continue secretLoop
-			}
-
-			var signers []Signer
-			if policy.Trust.SignerSecrets != nil {
-				// Generate a []Singer with the values for each signerSecret
-				signers = make([]Signer, len(policy.Trust.SignerSecrets))
-				for i, secretName := range policy.Trust.SignerSecrets {
-					signers[i], err = c.getSignerSecret(namespace, secretName.Name)
-					if err != nil {
-						a.StringToAdmissionResponse(fmt.Sprintf("Deny %q, could not get signerSecret from your cluster, %s", img.String(), err.Error()))
-						continue containerLoop
-					}
-				}
-			}
-
-			// Get image digest
-			glog.Info("getting signed image...")
-			notaryURL, err := img.GetContentTrustURL()
-			if err != nil {
-				a.StringToAdmissionResponse(fmt.Sprintf("Trust Server/Image Configuration Error: %v", err.Error()))
+				a.StringToAdmissionResponse(fmt.Sprintf("Deny %q, invalid image name", container.Image))
 				continue containerLoop
 			}
-			digest, err := c.getDigest(notaryURL, img.NameWithoutTag(), notaryToken, img.GetTag(), signers)
-			if err != nil {
-				if strings.Contains(err.Error(), "401") {
+
+			glog.Infof("Container Image: %s   Namespace: %s", img.String(), namespace)
+			if policy, err = c.policyClient.GetPolicyToEnforce(namespace, img.String()); err != nil {
+				a.StringToAdmissionResponse(err.Error())
+				continue containerLoop
+			} else if policy == nil || !(policy.Trust.Enabled != nil && *policy.Trust.Enabled == true) {
+				a.SetAllowed()
+				continue containerLoop
+			}
+
+			// Trust is enforced
+			glog.Info("Trust is enforced")
+
+			// Make sure image sure there is a ImagePullSecret defined
+			// TODO: This prevents use of signed publically available images with publically available signing data
+			var registryToken string
+			if len(pod.ImagePullSecrets) == 0 {
+				a.StringToAdmissionResponse(fmt.Sprintf("Deny %q, no ImagePullSecret defined for %s", img.String(), img.GetHostname()))
+				continue containerLoop
+			}
+
+		secretLoop:
+			for _, secret := range pod.ImagePullSecrets {
+				registryToken, err = c.kubeClientsetWrapper.GetSecretToken(namespace, secret.Name, img.GetHostname())
+				if err != nil {
+					glog.Error(err)
 					continue secretLoop
 				}
-				a.StringToAdmissionResponse(fmt.Sprintf("Deny %q, failed to get content trust information: %s", img.String(), err.Error()))
-				if _, ok := err.(store.ErrServerUnavailable); ok {
-					glog.Errorf("Trust server unavailable: %v", err)
-					return a.Flush()
+
+				notaryToken, err := c.cr.GetContentTrustToken(registryToken, img.NameWithoutTag(), img.GetRegistryURL())
+				if err != nil {
+					glog.Error(err)
+					continue secretLoop
 				}
-				glog.Warningf("Failed to get trust information for %q: %v", img.String(), err)
-				continue containerLoop
+
+				var signers []Signer
+				if policy.Trust.SignerSecrets != nil {
+					// Generate a []Singer with the values for each signerSecret
+					signers = make([]Signer, len(policy.Trust.SignerSecrets))
+					for i, secretName := range policy.Trust.SignerSecrets {
+						signers[i], err = c.getSignerSecret(namespace, secretName.Name)
+						if err != nil {
+							a.StringToAdmissionResponse(fmt.Sprintf("Deny %q, could not get signerSecret from your cluster, %s", img.String(), err.Error()))
+							continue containerLoop
+						}
+					}
+				}
+
+				// Get image digest
+				glog.Info("getting signed image...")
+				notaryURL, err := img.GetContentTrustURL()
+				if err != nil {
+					a.StringToAdmissionResponse(fmt.Sprintf("Trust Server/Image Configuration Error: %v", err.Error()))
+					continue containerLoop
+				}
+				digest, err := c.getDigest(notaryURL, img.NameWithoutTag(), notaryToken, img.GetTag(), signers)
+				if err != nil {
+					if strings.Contains(err.Error(), "401") {
+						continue secretLoop
+					}
+					a.StringToAdmissionResponse(fmt.Sprintf("Deny %q, failed to get content trust information: %s", img.String(), err.Error()))
+					if _, ok := err.(store.ErrServerUnavailable); ok {
+						glog.Errorf("Trust server unavailable: %v", err)
+						return a.Flush()
+					}
+					glog.Warningf("Failed to get trust information for %q: %v", img.String(), err)
+					continue containerLoop
+				}
+				glog.Infof("Mutation #: %d  Image name: %s", containerIndex+1, img.String())
+				if strings.Contains(container.Image, img.String()) {
+					glog.Infof("Mutated to: %s@sha256:%s", img.String(), digest.String())
+					patches = append(patches, types.JSONPatch{
+						Op:    "replace",
+						Path:  fmt.Sprintf("%s/%s/%s/image", specPath, containerType, strconv.Itoa(containerIndex)),
+						Value: fmt.Sprintf("%s@sha256:%s", img.NameWithTag(), digest.String()),
+					})
+				}
+				a.SetAllowed()
+				break secretLoop
 			}
-			glog.Infof("Mutation #: %d  Image name: %s", containerIndex+1, img.String())
-			if strings.Contains(container.Image, img.String()) {
-				glog.Infof("Mutated to: %s@sha256:%s", img.String(), digest.String())
-				patches = append(patches, types.JSONPatch{
-					Op:    "replace",
-					Path:  fmt.Sprintf("%s/containers/%s/image", specPath, strconv.Itoa(containerIndex)),
-					Value: fmt.Sprintf("%s@sha256:%s", img.NameWithTag(), digest.String()),
-				})
+			if !a.IsAllowed() {
+				a.StringToAdmissionResponse(fmt.Sprintf("Deny %q, no valid ImagePullSecret defined for %s", img.String(), img.GetHostname()))
 			}
-			a.SetAllowed()
-			break secretLoop
-		}
-		if !a.IsAllowed() {
-			a.StringToAdmissionResponse(fmt.Sprintf("Deny %q, no valid ImagePullSecret defined for %s", img.String(), img.GetHostname()))
 		}
 	}
 

--- a/pkg/controller/notary/controller.go
+++ b/pkg/controller/notary/controller.go
@@ -173,7 +173,7 @@ func (c *Controller) mutatePodSpec(namespace, specPath string, pod corev1.PodSpe
 					glog.Warningf("Failed to get trust information for %q: %v", img.String(), err)
 					continue containerLoop
 				}
-				glog.Infof("Mutation #: %d  Image name: %s", containerIndex+1, img.String())
+				glog.Infof("Mutation #: %s %d  Image name: %s", containerType, containerIndex+1, img.String())
 				if strings.Contains(container.Image, img.String()) {
 					glog.Infof("Mutated to: %s@sha256:%s", img.String(), digest.String())
 					patches = append(patches, types.JSONPatch{

--- a/pkg/controller/notary/notary_suite_test.go
+++ b/pkg/controller/notary/notary_suite_test.go
@@ -740,6 +740,134 @@ func newFakeRequestMultiContainer(image, image1 string) *http.Request {
 }
 
 // newFakeRequest creates a new http request
+func newFakeRequestInitContainer(initImage, image string) *http.Request {
+	// TODO: Delete what we don't need for unit tests
+	req, _ := http.NewRequest("POST", "/", bytes.NewBufferString(fmt.Sprintf(`
+		{
+		  "kind": "AdmissionReview",
+		  "apiVersion": "admission.k8s.io/v1beta1",
+		  "request": {
+		    "uid": "ed782967-1c99-11e8-936d-08002789d446",
+		    "kind": {
+		      "group": "",
+		      "version": "v1",
+		      "kind": "Pod"
+		    },
+		    "resource": {
+		      "group": "",
+		      "version": "v1",
+		      "resource": "pods"
+		    },
+		    "namespace": "default",
+		    "operation": "CREATE",
+		    "userInfo": {
+		      "username": "minikube-user",
+		      "groups": [
+		        "system:masters",
+		        "system:authenticated"
+		      ]
+		    },
+		    "object": {
+		      "metadata": {
+		        "name": "nginx",
+		        "namespace": "default",
+		        "creationTimestamp": null
+		      },
+		      "spec": {
+		        "volumes": [
+		          {
+		            "name": "default-token-xff4f",
+		            "secret": {
+		              "secretName": "default-token-xff4f"
+		            }
+		          }
+		        ],
+                "initContainers" : [
+				{
+		            "name": "nginx",
+		            "image": "%s",
+		            "ports": [
+		              {
+		                "hostPort": 8080,
+		                "containerPort": 8080,
+		                "protocol": "TCP"
+		              }
+		            ],
+		            "resources": {},
+		            "volumeMounts": [
+		              {
+		                "name": "default-token-xff4f",
+		                "readOnly": true,
+		                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+		              }
+		            ],
+		            "terminationMessagePath": "/dev/termination-log",
+		            "terminationMessagePolicy": "File",
+		            "imagePullPolicy": "Always"
+					}
+                ],
+		        "containers": [
+                 {
+		            "name": "statsd",
+		            "image": "%s",
+		            "ports": [
+		              {
+		                "hostPort": 8080,
+		                "containerPort": 8080,
+		                "protocol": "TCP"
+		              }
+		            ],
+		            "resources": {},
+		            "volumeMounts": [
+		              {
+		                "name": "default-token-xff4f",
+		                "readOnly": true,
+		                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+		              }
+		            ],
+		            "terminationMessagePath": "/dev/termination-log",
+		            "terminationMessagePolicy": "File",
+		            "imagePullPolicy": "Always"
+		          }
+		        ],
+		        "restartPolicy": "Always",
+		        "terminationGracePeriodSeconds": 30,
+		        "dnsPolicy": "ClusterFirst",
+		        "serviceAccountName": "default",
+		        "serviceAccount": "default",
+		        "hostNetwork": true,
+		        "securityContext": {},
+		        "imagePullSecrets": [
+		          {
+		            "name": "regsecret"
+		          }
+		        ],
+		        "schedulerName": "default-scheduler",
+		        "tolerations": [
+		          {
+		            "key": "node.kubernetes.io/not-ready",
+		            "operator": "Exists",
+		            "effect": "NoExecute",
+		            "tolerationSeconds": 300
+		          },
+		          {
+		            "key": "node.kubernetes.io/unreachable",
+		            "operator": "Exists",
+		            "effect": "NoExecute",
+		            "tolerationSeconds": 300
+		          }
+		        ]
+		      },
+		      "status": {}
+		    },
+		    "oldObject": null
+		  }
+		}`, initImage, image)))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+// newFakeRequest creates a new http request
 func newFakeRequestDeployment(image string) *http.Request {
 	// TODO: Delete what we don't need for unit tests
 	req, _ := http.NewRequest("POST", "/", bytes.NewBufferString(fmt.Sprintf(`

--- a/pkg/controller/notary/notary_test.go
+++ b/pkg/controller/notary/notary_test.go
@@ -679,7 +679,6 @@ var _ = Describe("Main", func() {
 					req := newFakeRequestInitContainer("registry.bluemix.net/hello", "registry.ng.bluemix.net/goodbye")
 					wh.HandleAdmissionRequest(w, req)
 					parseResponse()
-					fmt.Println(resp.Response.Allowed)
 					Expect(resp.Response.Allowed).To(BeFalse())
 				})
 			})

--- a/pkg/controller/notary/notary_test.go
+++ b/pkg/controller/notary/notary_test.go
@@ -657,6 +657,73 @@ var _ = Describe("Main", func() {
 					Expect(resp.Response.Allowed).To(BeFalse())
 				})
 			})
+
+			Context("if request container initContainers with non-compliant images", func() {
+				It("should deny the admission of the request", func() {
+					imageRepos := `"repositories": [
+						{
+							"name": "registry.ng.bluemix.net/*",
+							"policy": {
+								"trust": {
+									"enabled": false
+								},
+								"va": {
+									"enabled": false
+								}
+							}
+						}
+					]`
+					clusterRepos := `"repositories": []`
+					fakeEnforcer(imageRepos, clusterRepos)
+					updateController()
+					req := newFakeRequestInitContainer("registry.bluemix.net/hello", "registry.ng.bluemix.net/goodbye")
+					wh.HandleAdmissionRequest(w, req)
+					parseResponse()
+					fmt.Println(resp.Response.Allowed)
+					Expect(resp.Response.Allowed).To(BeFalse())
+				})
+			})
+
+			Context("if `trust` is enabled, initContainer pods require signing", func() {
+				It("should correctly mutate the initContainer field in the podspec", func() {
+					imageRepos := `"repositories": [
+                            {
+								"name": "registry.bluemix.net/*",
+								"policy": {
+									"trust": {
+										"enabled": false
+									},
+									"va": {
+										"enabled": false
+									}
+								}
+							},
+							{
+								"name": "registry.ng.bluemix.net/*",
+								"policy": {
+									"trust": {
+										"enabled": true
+									},
+									"va": {
+										"enabled": false
+									}
+								}
+							}
+						]`
+					clusterRepos := `"repositories": []`
+					fakeEnforcer(imageRepos, clusterRepos)
+					fakeGetRepo()
+					updateController()
+					req := newFakeRequestInitContainer("registry.ng.bluemix.net/hello", "registry.bluemix.net/nosign")
+					wh.HandleAdmissionRequest(w, req)
+					parseResponse()
+					Expect(string(resp.Response.Patch)).To(ContainSubstring("registry.ng.bluemix.net/hello:latest@sha256:31323334353637383930"))
+					// Check if added patch contains patch to initContainers
+					Expect(string(resp.Response.Patch)).To(ContainSubstring("initContainers"))
+					Expect(resp.Response.Allowed).To(BeTrue())
+				})
+			})
+
 		})
 	})
 })


### PR DESCRIPTION
Added support for applying policy to initContainers as per https://github.com/IBM/portieris/issues/30

The diffs are kind of strange because of the indentations. Only edits are actually on the top of `mutate` function and minor edits.

I had some trouble writing tests for checking the signing with a pod request. I ran into this error:
```
 Test Panicked
 GetNotaryRepo called before it is stubbed
```

I tried it with `newFakeRequestMultiContainer` and couldn't get it to work too. If someone could help me figure out the testing scaffolding, that would be great. 
 
Signed-off-by: Brandon Lum <lumjjb@gmail.com>