### PR TITLE
Update chart to 0.4.0 image

### DIFF
--- a/helm/portieris/values.yaml
+++ b/helm/portieris/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 3
 image:
   host: docker.io/ibmcom
   image: portieris
-  tag: 0.3.0
+  tag: 0.4.0
   pullPolicy: Always
 
 service:


### PR DESCRIPTION
0.4.0 is built from master at ff725c44cf2a853843ccf73890c2b17b63609774.

Closes #30 