### PR TITLE
Consume value for namespace in certs secret

### DIFF
--- a/helm/portieris/templates/secret.yaml
+++ b/helm/portieris/templates/secret.yaml
@@ -2,9 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: portieris-certs
-  namespace: ibm-system
+  namespace: {{ .Values.namespace }}
 type: Opaque
 data:
   serverCert.pem: {{ .Files.Get "certs/serverCert.pem" | b64enc }}
   serverKey.pem: {{ .Files.Get "certs/serverKey.pem" | b64enc }}
-  


### PR DESCRIPTION
This was missed in https://github.com/IBM/portieris/pull/24.