### PR TITLE
Don't assume that the username will be token

### DIFF
--- a/pkg/kubernetes/secret_test.go
+++ b/pkg/kubernetes/secret_test.go
@@ -47,7 +47,8 @@ func TestWrapper_GetSecretToken(t *testing.T) {
 		namespace  string
 		secretName string
 		registry   string
-		want       string
+		wantUser   string
+		wantPass   string
 		wantErr    bool
 	}{
 		{
@@ -57,7 +58,8 @@ func TestWrapper_GetSecretToken(t *testing.T) {
 			secretName: "name",
 			namespace:  "namespace",
 			registry:   "registry.ng.bluemix.net",
-			want:       "registry-token",
+			wantUser:   "token",
+			wantPass:   "registry-token",
 		},
 		{
 			name: "should return token for old imagePullSecret format",
@@ -66,7 +68,8 @@ func TestWrapper_GetSecretToken(t *testing.T) {
 			secretName: "name",
 			namespace:  "namespace",
 			registry:   "registry.ng.bluemix.net",
-			want:       "registry-token",
+			wantUser:   "token",
+			wantPass:   "registry-token",
 		},
 		{
 			name:       "error if secret not found",
@@ -109,12 +112,13 @@ func TestWrapper_GetSecretToken(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			kubeClientset := k8sfake.NewSimpleClientset(tt.secret)
 			w := NewKubeClientsetWrapper(kubeClientset)
-			got, err := w.GetSecretToken(tt.namespace, tt.secretName, tt.registry)
+			username, password, err := w.GetSecretToken(tt.namespace, tt.secretName, tt.registry)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tt.want, got)
+				assert.Equal(t, tt.wantUser, username)
+				assert.Equal(t, tt.wantPass, password)
 			}
 		})
 	}

--- a/pkg/kubernetes/wrapper.go
+++ b/pkg/kubernetes/wrapper.go
@@ -30,7 +30,7 @@ var _ WrapperInterface = &Wrapper{}
 type WrapperInterface interface {
 	kubernetes.Interface
 	GetPodSpec(*v1beta1.AdmissionRequest) (string, *corev1.PodSpec, error)
-	GetSecretToken(namespace, secretName, registry string) (string, error)
+	GetSecretToken(namespace, secretName, registry string) (string, string, error)
 }
 
 // Wrapper is a wrapper around kubeclientset that includes some helper functions for applying behaviour to kube resources

--- a/pkg/registry/fakeregistry/fakeregistry.go
+++ b/pkg/registry/fakeregistry/fakeregistry.go
@@ -16,16 +16,21 @@ package fakeregistry
 
 import (
 	"sync"
+
+	"github.com/IBM/portieris/pkg/registry"
 )
+
+var _ registry.Interface = &FakeRegistry{}
 
 // FakeRegistry .
 type FakeRegistry struct {
-	GetContentTrustTokenStub        func(registryToken, imageRepo, hostname string) (string, error)
+	GetContentTrustTokenStub        func(username, password, imageRepo, hostname string) (string, error)
 	getContentTrustTokenMutex       sync.RWMutex
 	getContentTrustTokenArgsForCall []struct {
-		registryToken string
-		imageRepo     string
-		hostname      string
+		username  string
+		password  string
+		imageRepo string
+		hostname  string
 	}
 	getContentTrustTokenReturns struct {
 		token string
@@ -34,16 +39,17 @@ type FakeRegistry struct {
 }
 
 // GetContentTrustToken ...
-func (fake *FakeRegistry) GetContentTrustToken(registryToken, imageRepo, hostname string) (string, error) {
+func (fake *FakeRegistry) GetContentTrustToken(username, password, imageRepo, hostname string) (string, error) {
 	fake.getContentTrustTokenMutex.Lock()
 	fake.getContentTrustTokenArgsForCall = append(fake.getContentTrustTokenArgsForCall, struct {
-		registryToken string
-		imageRepo     string
-		hostname      string
-	}{registryToken, imageRepo, hostname})
+		username  string
+		password  string
+		imageRepo string
+		hostname  string
+	}{username, password, imageRepo, hostname})
 	fake.getContentTrustTokenMutex.Unlock()
 	if fake.GetContentTrustTokenStub != nil {
-		return fake.GetContentTrustTokenStub(registryToken, imageRepo, hostname)
+		return fake.GetContentTrustTokenStub(username, password, imageRepo, hostname)
 	}
 	return fake.getContentTrustTokenReturns.token, fake.getContentTrustTokenReturns.err
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -23,7 +23,7 @@ type Client struct{}
 
 // Interface .
 type Interface interface {
-	GetContentTrustToken(registryToken, imageRepo, hostname string) (string, error)
+	GetContentTrustToken(username, password, imageRepo, hostname string) (string, error)
 }
 
 // NewClient .
@@ -32,8 +32,8 @@ func NewClient() Interface {
 }
 
 // GetContentTrustToken .
-func (c Client) GetContentTrustToken(registryToken, imageRepo, hostname string) (string, error) {
-	token, err := oauth.Request(registryToken, imageRepo, "token", false, "notary", hostname)
+func (c Client) GetContentTrustToken(username, password, imageRepo, hostname string) (string, error) {
+	token, err := oauth.Request(password, imageRepo, username, false, "notary", hostname)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Prevents "no valid IPS" errors when no pullSecret exists where the username is "token".