### PR TITLE
Remove deprecated sudo flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ go:
 cache:
   bundler: true
 
-sudo: required
-
 services:
   - docker
 


### PR DESCRIPTION
No longer required: https://changelog.travis-ci.com/the-container-based-build-environment-is-fully-deprecated-84517

Fixes https://github.com/IBM/portieris/issues/56