### PR TITLE
Add basic liveness and readiness probes

### DIFF
--- a/helm/portieris/templates/deployment.yaml
+++ b/helm/portieris/templates/deployment.yaml
@@ -33,6 +33,16 @@ spec:
           - name: portieris-certs
             readOnly: true
             mountPath: "/etc/certs"
+          livenessProbe:
+            httpGet:
+              port: 8000
+              path: "/health/liveness"
+              scheme: HTTPS
+          readinessProbe:
+            httpGet:
+              port: 8000
+              path: "/health/readiness"
+              scheme: HTTPS
           env:
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -79,6 +79,22 @@ func (s *Server) HandleAdmissionRequest(w http.ResponseWriter, r *http.Request) 
 	w.Write(reviewResponseToByte(admissionResponse, admissionReview))
 }
 
+// HandleLiveness responds to a Kubernetes Liveness probe
+// Fail this request if Kubernetes should restart this instance
+func (s *Server) HandleLiveness(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// HandleReadiness responds to a Kubernetes Readiness probe
+// Fail this request if this instance can't accept traffic, but Kubernetes shouldn't restart it
+func (s *Server) HandleReadiness(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	w.WriteHeader(http.StatusOK)
+}
+
 // Run starts the server
 func (s *Server) Run() {
 	flag.Parse()
@@ -100,6 +116,8 @@ func (s *Server) Run() {
 		ClientAuth: tls.NoClientCert,
 	}
 	s.mux.HandleFunc("/admit", s.HandleAdmissionRequest)
+	s.mux.HandleFunc("/health/liveness", s.HandleLiveness)
+	s.mux.HandleFunc("/health/readiness", s.HandleReadiness)
 	port := "8000"
 	server := &http.Server{
 		Addr:      fmt.Sprintf(":%s", port),


### PR DESCRIPTION
Implemented as separate checks in case we want to do something different later on.

https://github.com/IBM/portieris/issues/66