### PR TITLE
Run as non-root to work on Openshift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -tags containers_image_openpgp -o ./bin
 
 FROM scratch
 COPY --from=golang /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-# Create /tmp for log files
-WORKDIR /tmp 
-WORKDIR /
-COPY --from=golang /go/src/github.com/IBM/portieris/bin/trust .
-CMD ["./trust","--alsologtostderr","-v=4","2>&1"]
+COPY --from=golang /go/src/github.com/IBM/portieris/bin/trust /trust
+# Create /tmp for logs and /run for working directory
+RUN [ "/trust", "--mkdir",  "/tmp,/run" ]
+WORKDIR /run
+CMD ["/trust","--alsologtostderr","-v=4","2>&1"]

--- a/helm/portieris/templates/deployment.yaml
+++ b/helm/portieris/templates/deployment.yaml
@@ -48,6 +48,8 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+      securityContext:
+        runAsUser: 1000060001
       volumes:
       - name: portieris-certs
         secret:


### PR DESCRIPTION
Openshift requires that pods run as non-root - root pods won't start. There's some directories in the container's filesystem that need to be writable to Portieris, so added a little macro to the build that allows it to create the directories it needs with the permissions it needs to run as non-root.

Tested on an IBM Cloud Openshift cluster running Openshift 3.11.

Fixes https://github.com/IBM/portieris/issues/80