### PR TITLE
Remove dependency on yq

### DIFF
--- a/helm/portieris/README.md
+++ b/helm/portieris/README.md
@@ -20,8 +20,6 @@ This chart:
 ### !!! Regenerate Certs !!!
 The install will use the default certs if you do not run the gencerts script. **This means you will deploying with certs that are publically accessible on GitHub.**
 
-Note that this script requires https://github.com/mikefarah/yq to be installed. There are competing versions of yq with different syntax, so check that you have the right one. If `yq r` is a valid command, you have the right one. If `yq -r` is valid, you have a competing version that is incompatible with this script.
-
 ```
 ./gencerts
 ```
@@ -65,7 +63,7 @@ For information about configuring security policies, and an explanation of the s
     ```
     Alternatively, disable Portieris manually.
     ```
-    kubectl delete MutatingWebhookConfiguration image-admission-config 
+    kubectl delete MutatingWebhookConfiguration image-admission-config
     ```
 2. Remove the chart.
     ```

--- a/helm/portieris/gencerts
+++ b/helm/portieris/gencerts
@@ -2,7 +2,7 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-SERVICE_NAME=$(yq r $SCRIPT_DIR/Chart.yaml name)
+SERVICE_NAME=portieris
 NAMESPACE=${1:-ibm-system}
 
 echo "Using $SERVICE_NAME as the service name"


### PR DESCRIPTION
It looks like `yq` was only used to read the `name` from Chart.yaml. But is it likely that `name` will ever change from `portieris`? If not, I think we could make it easier to adopt portieris if we remove this dependency and just hard-code the service name.

My specific use-case is that I have to use a restricted bastion host to deploy my helm charts, and that bastion host doesn't have `yq` installed on it.

Feel free to close this PR if there is a situation where hardcoding `SERVICE_NAME=portieris` would cause problems. I may be missing the big-picture. 👍 