### PR TITLE
Add the ability to skip secret creation

### DIFF
--- a/helm/portieris/templates/secret.yaml
+++ b/helm/portieris/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.SkipSecretCreation }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ type: Opaque
 data:
   serverCert.pem: {{ .Files.Get "certs/serverCert.pem" | b64enc }}
   serverKey.pem: {{ .Files.Get "certs/serverKey.pem" | b64enc }}
+{{ end }}

--- a/helm/portieris/values.yaml
+++ b/helm/portieris/values.yaml
@@ -20,6 +20,9 @@ service:
 # If not running on IBM Cloud Container Service set to false
 IBMContainerService: true
 
+# If managing portieris-certs secret externally
+SkipSecretCreation: false
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Adding the ability to skip secret creation is useful so that the portieris-certs secret can be managed separately from the helm chart.