### PR TITLE
Support Helm3 and OpenShift

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Portieris' Admission Webhook is configured to fail closed. Three instances of Po
 
 ## Installing Portieris
 
-Portieris is installed using a Helm chart. Before you begin, make sure that you have Kubernetes 1.9 or above, and Helm 2.8 or above (not Helm 3.x) installed in your cluster.
+Portieris is installed using a Helm chart. Before you begin, make sure that you have Kubernetes 1.16 or above and Helm 3.0 or above installed in your cluster.
 
 To install Portieris:
 

--- a/helm/portieris/templates/clusterrole.yaml
+++ b/helm/portieris/templates/clusterrole.yaml
@@ -7,10 +7,13 @@ metadata:
     chart: {{ template "portieris.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "1"
 rules:
 - apiGroups: ["securityenforcement.admission.cloud.ibm.com"]
   resources: ["imagepolicies", "clusterimagepolicies"]
-  verbs: ["get", "watch", "list", "create"]
+  verbs: ["get", "watch", "list", "create", "patch"]
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
   verbs: ["get", "create", "delete"]

--- a/helm/portieris/templates/clusterrolebinding.yaml
+++ b/helm/portieris/templates/clusterrolebinding.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ template "portieris.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/helm/portieris/templates/crd-creation/configmap.yaml
+++ b/helm/portieris/templates/crd-creation/configmap.yaml
@@ -8,6 +8,9 @@ metadata:
     chart: {{ template "portieris.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "-7"
 data:
   custom-resource-definitions.yaml: |-
     {{- include "crds.yaml.tpl" . | indent 4}}

--- a/helm/portieris/templates/crd-creation/create-crds.yaml
+++ b/helm/portieris/templates/crd-creation/create-crds.yaml
@@ -4,7 +4,7 @@ metadata:
   name: create-crds
   namespace: {{ .Values.namespace }}
   annotations:
-    helm.sh/hook: post-install
+    helm.sh/hook: pre-install
     helm.sh/hook-weight: "-6"
     helm.sh/hook-delete-policy: hook-succeeded
   labels:

--- a/helm/portieris/templates/crd-creation/delete-crds.yaml
+++ b/helm/portieris/templates/crd-creation/delete-crds.yaml
@@ -4,7 +4,7 @@ metadata:
   name: delete-crds
   namespace: {{ .Values.namespace }}
   annotations:
-    helm.sh/hook: pre-delete
+    helm.sh/hook: post-delete
     helm.sh/hook-weight: "-9"
     helm.sh/hook-delete-policy: hook-succeeded
   labels:

--- a/helm/portieris/templates/deployment.yaml
+++ b/helm/portieris/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
       securityContext:
-        runAsUser: 1000060001
+        runAsUser: {{ .Values.securityContext.runAsUser }}
       volumes:
       - name: portieris-certs
         secret:

--- a/helm/portieris/templates/securitycontextconstraint.yaml
+++ b/helm/portieris/templates/securitycontextconstraint.yaml
@@ -1,0 +1,44 @@
+{{ if .Capabilities.APIVersions.Has "clusterversions.config.openshift.io" }}
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: []
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: []
+fsGroup:
+  type: RunAsAny
+groups:
+- system:cluster-admins
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: anyuid provides all features of the restricted SCC but allows users to run with any UID and any GID.
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "1"
+  name: anyuid-portieris
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: MustRunAs
+  uid: {{ .Values.securityContext.runAsUser }}
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:portieris:portieris
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret
+{{ end }}
+

--- a/helm/portieris/templates/securitycontextconstraint.yaml
+++ b/helm/portieris/templates/securitycontextconstraint.yaml
@@ -1,4 +1,12 @@
 {{ if .Capabilities.APIVersions.Has "clusterversions.config.openshift.io" }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: anyuid provides all features of the restricted SCC but allows users to run with any UID and any GID.
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "1"
+  name: anyuid-portieris
 allowHostDirVolumePlugin: false
 allowHostIPC: false
 allowHostNetwork: false
@@ -7,19 +15,11 @@ allowHostPorts: false
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: false
 allowedCapabilities: []
-apiVersion: security.openshift.io/v1
 defaultAddCapabilities: []
 fsGroup:
   type: RunAsAny
 groups:
 - system:cluster-admins
-kind: SecurityContextConstraints
-metadata:
-  annotations:
-    kubernetes.io/description: anyuid provides all features of the restricted SCC but allows users to run with any UID and any GID.
-    helm.sh/hook: pre-install
-    helm.sh/hook-weight: "1"
-  name: anyuid-portieris
 priority: 10
 readOnlyRootFilesystem: false
 requiredDropCapabilities:
@@ -41,4 +41,3 @@ volumes:
 - projected
 - secret
 {{ end }}
-

--- a/helm/portieris/templates/serviceaccount.yaml
+++ b/helm/portieris/templates/serviceaccount.yaml
@@ -12,3 +12,6 @@ metadata:
     chart: {{ template "portieris.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "-7"

--- a/helm/portieris/values.yaml
+++ b/helm/portieris/values.yaml
@@ -17,6 +17,9 @@ service:
   port: 443
   targetPort: 8000
 
+securityContext:
+  runAsUser: 1000060001
+
 # If not running on IBM Cloud Container Service set to false
 IBMContainerService: true
 


### PR DESCRIPTION
This enhancement adds support for OpenShift and Helm3.  To support Helm3 adjustments were made to hook annotations so that resources are applied in proper order during creation and deletion.  In addition, in order to successfully install the image/cluster image policies, the `patch` verb was added in the cluster role resource for apiGroup `securityenforcement.admission.cloud.ibm.com`.

To support OpenShift a security context contraint was added for the `portieris` service account.  This `scc` must be in place prior to instantiating the deployment, so the helm `pre-install` hook annotation was utilized.

Closes: https://github.com/IBM/portieris/issues/127
Closes: https://github.com/IBM/portieris/issues/124