### PR TITLE
Use a namespace selector for admission webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ To install Portieris in the default namespace (portieris):
 * Run `./helm/portieris/gencerts`. The `gencerts` script generates new SSL certificates and keys for Portieris. Portieris presents this certificates to the Kubernetes API server when the API server makes admission requests. If you do not generate new certificates, it could be possible for an attacker to spoof Portieris in your cluster.
 * Run `helm install portieris --create-namespace --namespace portieris helm/portieris`. `portieris` is the default namespace defined in the charts' `values.yaml` file.
 
-To use an alternative namespace:
+You can also use a different namespace if you choose. The Portieris install creates the namespace automatically, and the namespace will be deleted if you uninstall the Portieris chart, so make sure that Portieris is the only thing running in that namespace! To use an alternative namespace:
+
 * Run `./helm/portieris/gencerts <namespace>`.
 * Run `helm install portieris --create <namespace> --namespace <namespace> --set namespace=<namespace> helm/portieris`.
 
@@ -59,6 +60,8 @@ Image security policies define Portieris' behavior in your cluster. You must con
 ## Configuring access controls for your security policies
 
 You can configure Kubernetes RBAC rules to define which users and applications have the ability to modify your security policies. For more information, see the [IBM Cloud docs](https://cloud.ibm.com/docs/services/Registry?topic=registry-security_enforce#assign_user_policy).
+
+You can prevent Portieris' admission webhook from being called in specific namespaces by labelling the namespace with `securityenforcement.admission.cloud.ibm.com/namespace: skip`. Doing so would allow pods in that namespace to recover when the admission webhook is down, but note that no policies are applied in that namespace. For example, the Portieris install namespace is configured with this label to allow Portieris itself to recover when it is down. Make sure to control who can add labels to namespaces and who can access namespaces with this label so that a malicious party cannot use this label to bypass Portieris.
 
 ## Reporting security issues
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To manage certificates through installed [cert-manager](https://cert-manager.io/
 
 * Run `helm install portieris --set UseCertManager=true helm/portieris`.
 
-By default, Portieris' admission webhook does not run in namespaces with a skip annotation set, which includes its own install namespace, so that Portieris is able to self heal in the event where all its pods go down. You can disable this by adding `--set AllowAdmissionSkip=false` to your install command, however if all Portieris pods are down you'll have to disable the webhook to recover it manually.
+By default, Portieris' admission webhook runs in all namespaces including its own install namespace, so that Portieris is able to review all the pods in the cluster. However, this can prevent the cluster from self healing in the event where Portieris becomes unavailable. Portieris also supports skipping namespaces with a certain label set. You can enable this by adding `--set AllowAdmissionSkip=true` to your install command, but make sure to control who can add labels to namespaces and who can access namespaces with this label so that a malicious party cannot use this label to bypass Portieris.
 
 ## Uninstalling Portieris
 
@@ -61,7 +61,7 @@ Image security policies define Portieris' behavior in your cluster. You must con
 
 You can configure Kubernetes RBAC rules to define which users and applications have the ability to modify your security policies. For more information, see the [IBM Cloud docs](https://cloud.ibm.com/docs/services/Registry?topic=registry-security_enforce#assign_user_policy).
 
-You can prevent Portieris' admission webhook from being called in specific namespaces by labelling the namespace with `securityenforcement.admission.cloud.ibm.com/namespace: skip`. Doing so would allow pods in that namespace to recover when the admission webhook is down, but note that no policies are applied in that namespace. For example, the Portieris install namespace is configured with this label to allow Portieris itself to recover when it is down. Make sure to control who can add labels to namespaces and who can access namespaces with this label so that a malicious party cannot use this label to bypass Portieris.
+If Portieris is installed with `AllowAdmissionSkip=true`, you can prevent Portieris' admission webhook from being called in specific namespaces by labelling the namespace with `securityenforcement.admission.cloud.ibm.com/namespace: skip`. Doing so would allow pods in that namespace to recover when the admission webhook is down, but note that no policies are applied in that namespace. For example, the Portieris install namespace is configured with this label to allow Portieris itself to recover when it is down. Make sure to control who can add labels to namespaces and who can access namespaces with this label so that a malicious party cannot use this label to bypass Portieris.
 
 ## Reporting security issues
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,9 @@ If your cloud provider provides a [Notary](https://github.com/theupdateframework
 
 When you create or edit a workload, the Kubernetes API server sends a request to Portieris. The AdmissionRequest contains the content of your workload. For each image in your workload, Portieris finds a matching security policy.
 
-
 If trust enforcement is enabled in the policy, Portieris pulls signature information for your image from the corresponding Notary server and, if a signed version of the image exists, creates a JSON patch to edit the image name in the workload to the signed image by digest. If a signer is defined in the policy, Portieris additionally checks that the image is signed by the specified role, and verifies that the specified key was used to sign the image.
 
-
 If simple signing is specified by the policy, Portieris will verify the signature using using the public key and identity rules supplied in the policy and if verified similarly mutates the image name to a digest reference to ensure that concurrent tag changes cannot influence the image being pulled.
-
 
 While it is possible to require both Notary trust and simple signing, the two methods must agree on the signed digest for the image. If the two methods return different signed digests, the image is denied. It is not possible to allow alternative signing methods.
 
@@ -44,8 +41,11 @@ You can also use a different namespace if you choose. The Portieris install crea
 * Run `./helm/portieris/gencerts <namespace>`.
 * Run `helm install portieris --create <namespace> --namespace <namespace> --set namespace=<namespace> helm/portieris`.
 
-To manage certificates through installed cert-manager(https://cert-manager.io/):
+To manage certificates through installed [cert-manager](https://cert-manager.io/):
+
 * Run `helm install portieris --set UseCertManager=true helm/portieris`.
+
+By default, Portieris' admission webhook does not run in namespaces with a skip annotation set, which includes its own install namespace, so that Portieris is able to self heal in the event where all its pods go down. You can disable this by adding `--set AllowAdmissionSkip=false` to your install command, however if all Portieris pods are down you'll have to disable the webhook to recover it manually.
 
 ## Uninstalling Portieris
 

--- a/helm/portieris/templates/namespace.yaml
+++ b/helm/portieris/templates/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+  labels:
+    securityenforcement.admission.cloud.ibm.com/namespace: skip

--- a/helm/portieris/templates/webhooks.yaml
+++ b/helm/portieris/templates/webhooks.yaml
@@ -30,9 +30,11 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     admissionReviewVersions: ["v1beta1"]
+    {{ if .Values.AllowAdmissionSkip }}
     namespaceSelector:
       matchExpressions:
       - key: securityenforcement.admission.cloud.ibm.com/namespace
         operator: NotIn
         values:
         - skip
+    {{ end }}

--- a/helm/portieris/templates/webhooks.yaml
+++ b/helm/portieris/templates/webhooks.yaml
@@ -30,3 +30,9 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     admissionReviewVersions: ["v1beta1"]
+    namespaceSelector:
+      matchExpressions:
+      - key: securityenforcement.admission.cloud.ibm.com/namespace
+        operator: NotIn
+        values:
+        - skip

--- a/helm/portieris/values.yaml
+++ b/helm/portieris/values.yaml
@@ -68,3 +68,10 @@ affinity:
         topologyKey: "failure-domain.beta.kubernetes.io/zone"
       weight: 50
 
+# Allow an annotation to be used to skip the webhook. This is required for Portieris to be able to
+# self heal when it has no running pods, which could otherwise deadlock your cluster after an
+# outage.
+# However, if this is enabled, anyone with access to annotate namespaces could bypass Portieris by
+# setting the annotation on their namespaces. Therefore, be careful with your RBAC policies if you
+# enable this option!
+AllowAdmissionSkip: true

--- a/helm/portieris/values.yaml
+++ b/helm/portieris/values.yaml
@@ -74,4 +74,4 @@ affinity:
 # However, if this is enabled, anyone with access to annotate namespaces could bypass Portieris by
 # setting the annotation on their namespaces. Therefore, be careful with your RBAC policies if you
 # enable this option!
-AllowAdmissionSkip: true
+AllowAdmissionSkip: false


### PR DESCRIPTION
This prevents the webhook from being called for the Portieris install namespace, which means that Portieris can recover itself in the case of cluster failure.

Without this an approval from the Portieris webhook is needed to okay scaling itself up. This means that with no pods available, the webhook can't approve the recovery of any Portieris pods, and so the cluster deadlocks.

This change gives the Portieris chart ownership of the portieris install namespace, and labels it in such a way that we can filter for it in the webhook config.

It's configured as an opt out, rather than Istio's which is an opt in. All namespaces without the label are fair game.

By adding the namespace into the chart, it'll be deleted by Helm when the chart gets removed. And adding the label selector means that the label could be added to other namespaces to bypass Portieris. Both of these potential issues have been documented in the readme.

https://github.com/IBM/portieris/issues/112