### PR TITLE
Use cert-manager naming convention for portieris

### DIFF
--- a/cmd/trust/main.go
+++ b/cmd/trust/main.go
@@ -77,13 +77,13 @@ func main() {
 		glog.Fatal("Could not get trust client", err)
 	}
 
-	serverCert, err := ioutil.ReadFile("/etc/certs/serverCert.pem")
+	serverCert, err := ioutil.ReadFile("/etc/certs/tls.crt")
 	if err != nil {
-		glog.Fatal("Could not read /etc/certs/serverCert.pem", err)
+		glog.Fatal("Could not read /etc/certs/tls.crt", err)
 	}
-	serverKey, err := ioutil.ReadFile("/etc/certs/serverKey.pem")
+	serverKey, err := ioutil.ReadFile("/etc/certs/tls.key")
 	if err != nil {
-		glog.Fatal("Could not read /etc/certs/serverKey.pem", err)
+		glog.Fatal("Could not read /etc/certs/tls.key", err)
 	}
 
 	cr := registryclient.NewClient()

--- a/helm/portieris/gencerts
+++ b/helm/portieris/gencerts
@@ -29,9 +29,9 @@ openssl genrsa -out $CERT_DIR/caKey.pem 2048
 openssl req -x509 -new -nodes -key $CERT_DIR/caKey.pem -days 100000 -out $CERT_DIR/caCert.pem -subj "/CN=${SERVICE_NAME}_ca"
 
 # Create a server certiticate
-openssl genrsa -out $CERT_DIR/serverKey.pem 2048
+openssl genrsa -out $CERT_DIR/tls.key 2048
 # Note the CN is the DNS name of the service of the webhook.
-openssl req -new -key $CERT_DIR/serverKey.pem -out $CERT_DIR/server.csr -subj "/CN=${SERVICE_NAME}.${NAMESPACE}.svc" -config $CERT_DIR/server.conf
-openssl x509 -req -in $CERT_DIR/server.csr -CA $CERT_DIR/caCert.pem -CAkey $CERT_DIR/caKey.pem -CAcreateserial -out $CERT_DIR/serverCert.pem -days 100000 -extensions v3_req -extfile $CERT_DIR/server.conf
+openssl req -new -key $CERT_DIR/tls.key -out $CERT_DIR/server.csr -subj "/CN=${SERVICE_NAME}.${NAMESPACE}.svc" -config $CERT_DIR/server.conf
+openssl x509 -req -in $CERT_DIR/server.csr -CA $CERT_DIR/caCert.pem -CAkey $CERT_DIR/caKey.pem -CAcreateserial -out $CERT_DIR/tls.crt -days 100000 -extensions v3_req -extfile $CERT_DIR/server.conf
 
 rm $CERT_DIR/caKey.pem $CERT_DIR/server.conf $CERT_DIR/server.csr

--- a/helm/portieris/templates/secret.yaml
+++ b/helm/portieris/templates/secret.yaml
@@ -6,6 +6,6 @@ metadata:
   namespace: {{ .Values.namespace }}
 type: Opaque
 data:
-  serverCert.pem: {{ .Files.Get "certs/serverCert.pem" | b64enc }}
-  serverKey.pem: {{ .Files.Get "certs/serverKey.pem" | b64enc }}
+  tls.crt: {{ .Files.Get "certs/tls.crt" | b64enc }}
+  tls.key: {{ .Files.Get "certs/tls.key" | b64enc }}
 {{ end }}


### PR DESCRIPTION
Rename portieris certs from serverCert.pem and serverKey.pem to tls.crt
and tls.key, following the naming conventions used by cert-manager.
In combination with SkipSecretCreation=true, this allows using
cert-manager to generate portieris certs.

https://github.com/IBM/portieris/issues/59

Signed-off-by: Joseph Richard <jrichard@josephrichard.com>