### PR TITLE
Use cert-manager naming convention for portieris

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Change the default namespace to portieris ([#117](https://github.com/IBM/portieris/issues/117))
 * Support Helm3 and Openshift 4 ([#130](https://github.com/IBM/portieris/pull/130))
-* anti-affinity and liveness/readiness probes  ([#66](https://github.com/IBM/portieris/issues/66)) 
+* anti-affinity and liveness/readiness probes  ([#66](https://github.com/IBM/portieris/issues/66))
+* Support sourcing webhook certificates from cert-manager ([#59](https://github.com/IBM/portieris/issues/59))
 
 # 0.7.0
 ## 2020-06-09

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ To use an alternative namespace:
 * Run `kubectl create namespace <namespace>`.
 * Run `helm install portieris --set namespace=<namespace> helm/portieris`.
 
+To manage certificates through installed cert-manager(https://cert-manager.io/):
+* Run `helm install portieris --set UseCertManager=true helm/portieris`.
+
 ## Uninstalling Portieris
 
 You can uninstall Portieris at any time by running `helm delete portieris`. Note that all your image security policies are deleted when you uninstall Portieris.

--- a/cmd/trust/main.go
+++ b/cmd/trust/main.go
@@ -77,13 +77,13 @@ func main() {
 		glog.Fatal("Could not get trust client", err)
 	}
 
-	serverCert, err := ioutil.ReadFile("/etc/certs/serverCert.pem")
+	serverCert, err := ioutil.ReadFile("/etc/certs/tls.crt")
 	if err != nil {
-		glog.Fatal("Could not read /etc/certs/serverCert.pem", err)
+		glog.Fatal("Could not read /etc/certs/tls.crt", err)
 	}
-	serverKey, err := ioutil.ReadFile("/etc/certs/serverKey.pem")
+	serverKey, err := ioutil.ReadFile("/etc/certs/tls.key")
 	if err != nil {
-		glog.Fatal("Could not read /etc/certs/serverKey.pem", err)
+		glog.Fatal("Could not read /etc/certs/tls.key", err)
 	}
 
 	cr := registryclient.NewClient()

--- a/helm/portieris/gencerts
+++ b/helm/portieris/gencerts
@@ -26,12 +26,12 @@ EOF
 
 # Create a certificate authority
 openssl genrsa -out $CERT_DIR/caKey.pem 2048
-openssl req -x509 -new -nodes -key $CERT_DIR/caKey.pem -days 100000 -out $CERT_DIR/caCert.pem -subj "/CN=${SERVICE_NAME}_ca"
+openssl req -x509 -new -nodes -key $CERT_DIR/caKey.pem -days 100000 -out $CERT_DIR/ca.crt -subj "/CN=${SERVICE_NAME}_ca"
 
 # Create a server certiticate
-openssl genrsa -out $CERT_DIR/serverKey.pem 2048
+openssl genrsa -out $CERT_DIR/tls.key 2048
 # Note the CN is the DNS name of the service of the webhook.
-openssl req -new -key $CERT_DIR/serverKey.pem -out $CERT_DIR/server.csr -subj "/CN=${SERVICE_NAME}.${NAMESPACE}.svc" -config $CERT_DIR/server.conf
-openssl x509 -req -in $CERT_DIR/server.csr -CA $CERT_DIR/caCert.pem -CAkey $CERT_DIR/caKey.pem -CAcreateserial -out $CERT_DIR/serverCert.pem -days 100000 -extensions v3_req -extfile $CERT_DIR/server.conf
+openssl req -new -key $CERT_DIR/tls.key -out $CERT_DIR/server.csr -subj "/CN=${SERVICE_NAME}.${NAMESPACE}.svc" -config $CERT_DIR/server.conf
+openssl x509 -req -in $CERT_DIR/server.csr -CA $CERT_DIR/ca.crt -CAkey $CERT_DIR/caKey.pem -CAcreateserial -out $CERT_DIR/tls.crt -days 100000 -extensions v3_req -extfile $CERT_DIR/server.conf
 
 rm $CERT_DIR/caKey.pem $CERT_DIR/server.conf $CERT_DIR/server.csr

--- a/helm/portieris/templates/admission-webhooks/webhooks.yaml
+++ b/helm/portieris/templates/admission-webhooks/webhooks.yaml
@@ -16,7 +16,7 @@ webhooks:
         name: {{ template "portieris.name" . }}
         namespace: {{ .Values.namespace }}
         path: "/admit"
-      caBundle: {{ .Files.Get "certs/caCert.pem" | b64enc }}
+      caBundle: {{ .Files.Get "certs/ca.crt" | b64enc }}
     rules:
       - operations: [ "CREATE", "UPDATE" ]
         apiGroups: ["*"]

--- a/helm/portieris/templates/admission-webhooks/webhooks.yaml
+++ b/helm/portieris/templates/admission-webhooks/webhooks.yaml
@@ -3,6 +3,10 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
   name: image-admission-config
+  {{ if .Values.UseCertManager }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Values.namespace }}/portieris-certs
+  {{ end }}
   namespace: {{ .Values.namespace }}
   labels:
     app: {{ template "portieris.name" . }}
@@ -16,7 +20,9 @@ webhooks:
         name: {{ template "portieris.name" . }}
         namespace: {{ .Values.namespace }}
         path: "/admit"
+      {{ if not .Values.UseCertManager }}
       caBundle: {{ .Files.Get "certs/ca.crt" | b64enc }}
+      {{ end }}
     rules:
       - operations: [ "CREATE", "UPDATE" ]
         apiGroups: ["*"]

--- a/helm/portieris/templates/secret.yaml
+++ b/helm/portieris/templates/secret.yaml
@@ -1,4 +1,25 @@
 {{ if not .Values.SkipSecretCreation }}
+{{ if .Values.UseCertManager }}
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: portieris
+  namespace: {{ .Values.namespace }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: portieris-certs
+  namespace: {{ .Values.namespace }}
+spec:
+  dnsNames:
+    - portieris.{{ .Values.namespace }}.svc
+  secretName: portieris-certs
+  issuerRef:
+    name: portieris
+{{ else }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,4 +29,5 @@ type: Opaque
 data:
   tls.crt: {{ .Files.Get "certs/tls.crt" | b64enc }}
   tls.key: {{ .Files.Get "certs/tls.key" | b64enc }}
+{{ end }}
 {{ end }}

--- a/helm/portieris/templates/secret.yaml
+++ b/helm/portieris/templates/secret.yaml
@@ -6,6 +6,6 @@ metadata:
   namespace: {{ .Values.namespace }}
 type: Opaque
 data:
-  serverCert.pem: {{ .Files.Get "certs/serverCert.pem" | b64enc }}
-  serverKey.pem: {{ .Files.Get "certs/serverKey.pem" | b64enc }}
+  tls.crt: {{ .Files.Get "certs/tls.crt" | b64enc }}
+  tls.key: {{ .Files.Get "certs/tls.key" | b64enc }}
 {{ end }}

--- a/helm/portieris/values.yaml
+++ b/helm/portieris/values.yaml
@@ -26,6 +26,9 @@ IBMContainerService: true
 # If managing portieris-certs secret externally
 SkipSecretCreation: false
 
+# If using cert-manager to handle secrets
+UseCertManager: false
+
 # Resoures defined to assist scheduling
 # request is typical x10, limit is typical x100
 resources:


### PR DESCRIPTION
Rename portieris certs from serverCert.pem and serverKey.pem to tls.crt
and tls.key, following the naming conventions used by cert-manager.
In combination with SkipSecretCreation=true, this allows using
cert-manager to generate portieris certs.

https://github.com/IBM/portieris/issues/59

Signed-off-by: Joseph Richard <jrichard@josephrichard.com>