### PR TITLE
Set service protocol appropriately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 # 0.7.1
 ## 2020-06-xx
 
+* Fix the port name in service template ([PR#149](https://github.com/IBM/portieris/pull/149))
 * Change the default namespace to portieris ([#117](https://github.com/IBM/portieris/issues/117))
 * Support Helm3 and Openshift 4 ([#130](https://github.com/IBM/portieris/pull/130))
 * anti-affinity and liveness/readiness probes  ([#66](https://github.com/IBM/portieris/issues/66)) 

--- a/helm/portieris/templates/service.yaml
+++ b/helm/portieris/templates/service.yaml
@@ -14,7 +14,7 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
-      name: http
+      name: https
   selector:
     app: {{ template "portieris.name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
The Portieris server is a HTTPS one, but we were saying it was HTTP in the service. This incorrect protocol reportedly breaks Istio's proxying of TLS requests.