### PR TITLE
--purge has been removed from helm 3

### DIFF
--- a/helm/portieris/README.md
+++ b/helm/portieris/README.md
@@ -67,5 +67,5 @@ For information about configuring security policies, and an explanation of the s
     ```
 2. Remove the chart.
     ```
-    helm delete --purge portieris
+    helm delete portieris
     ```


### PR DESCRIPTION
The default behavior is to --purge and if you want to retain your history you now need to explicitly use, when deleting/uninstalling, --keep-history