### PR TITLE
adjust helm usage - optimize/adjust docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,17 @@ To install Portieris in the default namespace (portieris):
 * Clone the Portieris Git repository to your workstation.
 * Change directory into the Portieris Git repository.
 * Run `./helm/portieris/gencerts`. The `gencerts` script generates new SSL certificates and keys for Portieris. Portieris presents this certificates to the Kubernetes API server when the API server makes admission requests. If you do not generate new certificates, it could be possible for an attacker to spoof Portieris in your cluster.
-* Run `kubectl create namespace portieris`
-* Run `helm install portieris helm/portieris`.
+* Run `helm install portieris --create-namespace --namespace portieris helm/portieris`. `portieris` is the default namespace defined in the charts' `values.yaml` file.
 
 To use an alternative namespace:
 * Run `./helm/portieris/gencerts <namespace>`.
-* Run `kubectl create namespace <namespace>`.
-* Run `helm install portieris --set namespace=<namespace> helm/portieris`.
+* Run `helm install portieris --create <namespace> --namespace <namespace> --set namespace=<namespace> helm/portieris`.
 
 ## Uninstalling Portieris
 
-You can uninstall Portieris at any time by running `helm delete portieris`. Note that all your image security policies are deleted when you uninstall Portieris.
+You can uninstall Portieris, at any time, by running `helm delete portieris --namespace <namespace>`. Note that 1.) all your image security policies are deleted when you uninstall Portieris and 2.) the namespace you created will need to be manually deleted. ie. `kubectl delete namespace/<namespace>`
+
+**Note**: if you have issues uninstalling portieris, via helm, try running the cleanup script: `helm/cleanup.sh portieris <namespace>`
 
 ## Image security policies
 

--- a/helm/cleanup.sh
+++ b/helm/cleanup.sh
@@ -1,16 +1,15 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 RELEASE_NAME=${1:-portieris}
 NAMESPACE=${2:-portieris}
 
-echo Deleting release ${RELEASE_NAME} in ${NAMESPACE}
+echo Deleting release "${RELEASE_NAME}" in "${NAMESPACE}"
 
 kubectl delete MutatingWebhookConfiguration image-admission-config --ignore-not-found=true
 kubectl delete ValidatingWebhookConfiguration image-admission-config --ignore-not-found=true
 
 kubectl delete crd clusterimagepolicies.securityenforcement.admission.cloud.ibm.com imagepolicies.securityenforcement.admission.cloud.ibm.com --ignore-not-found=true
 
-kubectl delete jobs -n ${NAMESPACE} create-admission-webhooks create-armada-image-policies create-crds validate-crd-creation --ignore-not-found=true
+kubectl delete jobs -n "${NAMESPACE}" create-admission-webhooks create-armada-image-policies create-crds validate-crd-creation --ignore-not-found=true
 
-helm delete ${RELEASE_NAME} --no-hooks 
-
+helm delete "${RELEASE_NAME}" --no-hooks --namespace "${NAMESPACE}"


### PR DESCRIPTION
Since we're using helm 3, allow it to create the namespace for us. adjust the documentation, on deleting, as helm delete will not find the release if not in the 'default' namespace. Additionally, notify user that any created namespaces are not cleaned up on a helm delete.
