### PR TITLE
Adding creating secret example

### DIFF
--- a/POLICIES.md
+++ b/POLICIES.md
@@ -66,9 +66,13 @@ spec:
 For more information, see the [IBM Cloud docs](https://cloud.ibm.com/docs/services/Registry?topic=registry-security_enforce#customize_policies).
 
 ### simple (RedHat simple signing)
-The policy requirements are similar to those defined for configuration files consulted when using the RedHat tools [policy requirements](https://github.com/containers/image/blob/master/docs/containers-policy.json.5.md#policy-requirements). However there are some differences, the main difference is that the public key in a "signedBy" requirement is defined in a "KeySecret:" attribute, the value is the name of an in-scope Kubernetes secret containing the public key data. The value of "KeyType" is implied and cannot be provided.
+The policy requirements are similar to those defined for configuration files consulted when using the RedHat tools [policy requirements](https://github.com/containers/image/blob/master/docs/containers-policy.json.5.md#policy-requirements). However there are some differences, the main difference is that the public key in a "signedBy" requirement is defined in a `keySecret:` attribute, the value is the name of an in-scope Kubernetes secret containing the public key data. 
 
-this example requires that images from `icr.io` are signed by the identity with public key in `my-pubkey`:
+In creating the secret, ensure you are creating the key with a value of `key`, as shown below:
+
+`kubectl create secret generic my-pubkey --from-file=key=<your_pub_key>`
+
+This example requires that images from `icr.io` are signed by the identity with public key in `my-pubkey`:
 ```yaml
 apiVersion: securityenforcement.admission.cloud.ibm.com/v1beta1
 kind: ImagePolicy

--- a/POLICIES.md
+++ b/POLICIES.md
@@ -66,7 +66,7 @@ spec:
 For more information, see the [IBM Cloud docs](https://cloud.ibm.com/docs/services/Registry?topic=registry-security_enforce#customize_policies).
 
 ### simple (RedHat simple signing)
-The policy requirements are similar to those defined for configuration files consulted when using the RedHat tools [policy requirements](https://github.com/containers/image/blob/master/docs/containers-policy.json.5.md#policy-requirements). However there are some differences, the main difference is that the public key in a`signedBy` requirement is defined in a `keySecret` attribute, the value is the name of an in-scope Kubernetes secret containing a public key block. The value of `keyType` is implied and cannot be provided. If multiple keys are present in the block then the requirement is satisfied if the signature is signed by any of them.
+The policy requirements are similar to those defined for configuration files consulted when using the RedHat tools [policy requirements](https://github.com/containers/image/blob/master/docs/containers-policy.json.5.md#policy-requirements). However there are some differences, the main difference is that the public key in a`signedBy` requirement is defined in a `keySecret` attribute, the value is the name of an in-scope Kubernetes secret containing a public key block. The value of `keyType`, `keyPath` and `keyData` (seen in [policy requirements](https://github.com/containers/image/blob/master/docs/containers-policy.json.5.md#policy-requirements)) cannot be provided. If multiple keys are present in the keyring then the requirement is satisfied if the signature is signed by any of them.
 
 To export a single public key identified by `<finger-print>` from gpg and create a KeySecret from it you could use: 
 ```bash

--- a/helm/portieris/README.md
+++ b/helm/portieris/README.md
@@ -67,5 +67,5 @@ For information about configuring security policies, and an explanation of the s
     ```
 2. Remove the chart.
     ```
-    helm delete portieris
+    helm delete --purge portieris
     ```

--- a/helm/portieris/README.md
+++ b/helm/portieris/README.md
@@ -67,5 +67,5 @@ For information about configuring security policies, and an explanation of the s
     ```
 2. Remove the chart.
     ```
-    helm delete --purge portieris
+    helm delete portieris
     ```


### PR DESCRIPTION
In setting this up using the latest feature of look-aside signatures, last week, I spent a few hours trying to understand how the secret should have been created - particularly the name of the key it was looking for. Naming it anything other than 'key' would not work. By default, i believe it picks up the basename of the file. Either way, adding an example for clarity.

Lastly, when I was trying to figure out how to configure for look-aside, I could not find anything relevant to the statement mentioning 'KeyType' and removed it. The literal word 'KeyType' does not show anywhere in the doc and it was a little confusing to read.