### PR TITLE
Allow anonymous notary access

### DIFF
--- a/pkg/notary/notary.go
+++ b/pkg/notary/notary.go
@@ -90,9 +90,17 @@ func (c Client) makeHubTransport(notaryToken string) http.RoundTripper {
 
 	modifiers := []transport.RequestModifier{
 		transport.NewHeaderRequestModifier(http.Header{
-			"User-Agent":    []string{"portieris-client"},
-			"Authorization": []string{fmt.Sprintf("Bearer %s", notaryToken)},
+			"User-Agent": []string{"portieris-client"},
 		}),
+	}
+
+	if notaryToken != "" {
+		modifiers = []transport.RequestModifier{
+			transport.NewHeaderRequestModifier(http.Header{
+				"User-Agent":    []string{"portieris-client"},
+				"Authorization": []string{fmt.Sprintf("Bearer %s", notaryToken)},
+			}),
+		}
 	}
 
 	return transport.NewTransport(base, modifiers...)

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -34,6 +34,9 @@ func NewClient() Interface {
 
 // GetContentTrustToken .
 func (c Client) GetContentTrustToken(username, password, imageRepo, hostname string) (string, error) {
+	if username == "" && password == "" {
+		return "", nil
+	}
 	token, err := oauth.Request(password, imageRepo, username, false, "notary", hostname)
 	if err != nil {
 		return "", err

--- a/pkg/verifier/trust/verifier.go
+++ b/pkg/verifier/trust/verifier.go
@@ -74,6 +74,7 @@ func (v *Verifier) VerifyByPolicy(namespace string, img *image.Reference, creden
 		}
 	}
 
+	credentials = append(credentials, []string{"", ""})
 	for _, cred := range credentials {
 		notaryToken, err := v.cr.GetContentTrustToken(cred[0], cred[1], img.NameWithoutTag(), img.GetRegistryURL())
 		if err != nil {


### PR DESCRIPTION
Allow access to anonymous notary servers (those without authentication turned on). I found this to be necessary when running my own notary server for storing signatures of images in ECR.

I did this by suffixing username "" password "" to the end of the real credentials array, and having methods that hit oauth and compose authentication headers be aware of this.

Opening in draft to get feedback on the approach while I'm continuing to test.