### PR TITLE
Make gencerts safe for directories containing spaces

### DIFF
--- a/helm/portieris/gencerts
+++ b/helm/portieris/gencerts
@@ -10,10 +10,10 @@ echo "Using $NAMESPACE as the namespace"
 
 CERT_DIR=$SCRIPT_DIR/certs
 
-rm -rf $CERT_DIR
-mkdir -p $CERT_DIR
+rm -rf "$CERT_DIR"
+mkdir -p "$CERT_DIR"
 
-cat > $CERT_DIR/server.conf << EOF
+cat > "$CERT_DIR"/server.conf << EOF
 [req]
 req_extensions = v3_req
 distinguished_name = req_distinguished_name
@@ -25,13 +25,13 @@ extendedKeyUsage = clientAuth, serverAuth
 EOF
 
 # Create a certificate authority
-openssl genrsa -out $CERT_DIR/caKey.pem 2048
-openssl req -x509 -new -nodes -key $CERT_DIR/caKey.pem -days 100000 -out $CERT_DIR/ca.crt -subj "/CN=${SERVICE_NAME}_ca"
+openssl genrsa -out "$CERT_DIR"/caKey.pem 2048
+openssl req -x509 -new -nodes -key "$CERT_DIR"/caKey.pem -days 100000 -out "$CERT_DIR"/ca.crt -subj "/CN=${SERVICE_NAME}_ca"
 
 # Create a server certiticate
-openssl genrsa -out $CERT_DIR/tls.key 2048
+openssl genrsa -out "$CERT_DIR"/tls.key 2048
 # Note the CN is the DNS name of the service of the webhook.
-openssl req -new -key $CERT_DIR/tls.key -out $CERT_DIR/server.csr -subj "/CN=${SERVICE_NAME}.${NAMESPACE}.svc" -config $CERT_DIR/server.conf
-openssl x509 -req -in $CERT_DIR/server.csr -CA $CERT_DIR/ca.crt -CAkey $CERT_DIR/caKey.pem -CAcreateserial -out $CERT_DIR/tls.crt -days 100000 -extensions v3_req -extfile $CERT_DIR/server.conf
+openssl req -new -key "$CERT_DIR"/tls.key -out "$CERT_DIR"/server.csr -subj "/CN=${SERVICE_NAME}.${NAMESPACE}.svc" -config "$CERT_DIR"/server.conf
+openssl x509 -req -in "$CERT_DIR"/server.csr -CA "$CERT_DIR"/ca.crt -CAkey "$CERT_DIR"/caKey.pem -CAcreateserial -out "$CERT_DIR"/tls.crt -days 100000 -extensions v3_req -extfile "$CERT_DIR"/server.conf
 
-rm $CERT_DIR/caKey.pem $CERT_DIR/server.conf $CERT_DIR/server.csr
+rm "$CERT_DIR"/caKey.pem "$CERT_DIR"/server.conf "$CERT_DIR"/server.csr


### PR DESCRIPTION
Previous version failed in automation if the working directory contained spaces in any directory names.