### PR TITLE
Assign a weighting to namespace pre-install

### DIFF
--- a/helm/portieris/templates/namespace.yaml
+++ b/helm/portieris/templates/namespace.yaml
@@ -5,5 +5,6 @@ metadata:
   name: {{ .Values.namespace }}
   annotations:
     "helm.sh/hook": "pre-install"
+    helm.sh/hook-weight: "-8"
   labels:
     securityenforcement.admission.cloud.ibm.com/namespace: skip


### PR DESCRIPTION
Higher in priority than serviceaccount
Fixes https://github.com/IBM/portieris/issues/181