### PR TITLE
Prepare for 0.8.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,14 @@
 Notable changes recorded here.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-# v0.8.0next
-## 2020-
+# v0.8.1
+## 2020-09-18
 
+* PR checker fixed to fail when tests fail ([#167](https://github.com/IBM/portieris/issues/167))
+* Helm3 currency items ([#141](https://github.com/IBM/portieris/issues/141)) ([#41](https://github.com/IBM/portieris/issues/41)) ([#89](https://github.com/IBM/portieris/issues/89))
+* Ability to use a namespace selector for admission webhook ([#112](https://github.com/IBM/portieris/issues/112))
+* Correctly decode pull secrets where credentials are in the auth field ([#174](https://github.com/IBM/portieris/issues/174))
+* Ensure the pre-install steps create the namespace before the serviceaccount ([#181](https://github.com/IBM/portieris/issues/181))
 
 # 0.8.0
 ## 2020-09-02

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GOFILES=$(shell find . -type f -name '*.go' -not -path "./code-generator/*")
 GOPACKAGES=$(shell go list ./... | grep -v test/ | grep -v pkg/apis/)
 
-VERSION=0.8.0next
+VERSION=0.8.1
 TAG=$(VERSION)
 GOTAGS='containers_image_openpgp'
 

--- a/helm/portieris/Chart.yaml
+++ b/helm/portieris/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: portieris
-version: 0.8.0next
+version: 0.8.1
 description: Admission Controller webhook for enforcing image trust in your cluster
 maintainer:
   - stuart.hayton@uk.ibm.com

--- a/helm/portieris/values.yaml
+++ b/helm/portieris/values.yaml
@@ -9,7 +9,7 @@ image:
   host:
   pullSecret:
   image: portieris
-  tag: 0.8.0next
+  tag: 0.8.1
   pullPolicy: Always
 
 service:

--- a/test/e2e/notary.ibm.clusterimagepolicy_test.go
+++ b/test/e2e/notary.ibm.clusterimagepolicy_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestNotary_ClusterImagePolicyRepositories_AllowAllDenyAll(t *testing.T) {
 	utils.CheckIfTesting(t, testTrustClusterImagePolicy)
-	if defaultClusterPolicy := utils.DeleteThenReturnClusterImagePolicy(t, framework, "ibmcloud-default-cluster-image-policy"); defaultClusterPolicy != nil {
+	if defaultClusterPolicy := utils.DeleteThenReturnClusterImagePolicy(t, framework, "default"); defaultClusterPolicy != nil {
 		defer framework.CreateClusterImagePolicy(defaultClusterPolicy)
 	}
 
@@ -43,7 +43,7 @@ func TestNotary_ClusterImagePolicyRepositories_AllowAllDenyAll(t *testing.T) {
 
 func TestNotary_ClusterImagePolicyRepositories_BasicTrust(t *testing.T) {
 	utils.CheckIfTesting(t, testTrustClusterImagePolicy)
-	if defaultClusterPolicy := utils.DeleteThenReturnClusterImagePolicy(t, framework, "ibmcloud-default-cluster-image-policy"); defaultClusterPolicy != nil {
+	if defaultClusterPolicy := utils.DeleteThenReturnClusterImagePolicy(t, framework, "default"); defaultClusterPolicy != nil {
 		defer framework.CreateClusterImagePolicy(defaultClusterPolicy)
 	}
 
@@ -61,7 +61,7 @@ func TestNotary_ClusterImagePolicyRepositories_BasicTrust(t *testing.T) {
 
 func TestNotary_ClusterImagePolicyRepositories_TrustPinning(t *testing.T) {
 	utils.CheckIfTesting(t, testTrustClusterImagePolicy)
-	if defaultClusterPolicy := utils.DeleteThenReturnClusterImagePolicy(t, framework, "ibmcloud-default-cluster-image-policy"); defaultClusterPolicy != nil {
+	if defaultClusterPolicy := utils.DeleteThenReturnClusterImagePolicy(t, framework, "default"); defaultClusterPolicy != nil {
 		defer framework.CreateClusterImagePolicy(defaultClusterPolicy)
 	}
 

--- a/test/e2e/notary.ibm.imagepolicy_test.go
+++ b/test/e2e/notary.ibm.imagepolicy_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestNotary_ImagePolicyRepositories_AllowAllDenyAll(t *testing.T) {
 	utils.CheckIfTesting(t, testTrustImagePolicy)
-	if defaultClusterPolicy := utils.DeleteThenReturnClusterImagePolicy(t, framework, "ibmcloud-default-cluster-image-policy"); defaultClusterPolicy != nil {
+	if defaultClusterPolicy := utils.DeleteThenReturnClusterImagePolicy(t, framework, "default"); defaultClusterPolicy != nil {
 		defer framework.CreateClusterImagePolicy(defaultClusterPolicy)
 	}
 

--- a/test/e2e/simple.imagePolicy_test.go
+++ b/test/e2e/simple.imagePolicy_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestSimple_ImagePolicyRepositories_AllowAllDenyAll(t *testing.T) {
 	utils.CheckIfTesting(t, testSimpleImagePolicy)
-	if defaultClusterPolicy := utils.DeleteThenReturnClusterImagePolicy(t, framework, "ibmcloud-default-cluster-image-policy"); defaultClusterPolicy != nil {
+	if defaultClusterPolicy := utils.DeleteThenReturnClusterImagePolicy(t, framework, "default"); defaultClusterPolicy != nil {
 		defer framework.CreateClusterImagePolicy(defaultClusterPolicy)
 	}
 

--- a/test/e2e/wildcard.generic_test.go
+++ b/test/e2e/wildcard.generic_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestWildcards_ImagePolicyRepositories_Wildcards(t *testing.T) {
 	utils.CheckIfTesting(t, testWildcardImagePolicy)
-	if defaultClusterPolicy := utils.DeleteThenReturnClusterImagePolicy(t, framework, "ibmcloud-default-cluster-image-policy"); defaultClusterPolicy != nil {
+	if defaultClusterPolicy := utils.DeleteThenReturnClusterImagePolicy(t, framework, "default"); defaultClusterPolicy != nil {
 		defer framework.CreateClusterImagePolicy(defaultClusterPolicy)
 	}
 


### PR DESCRIPTION
and minor fixes to e2e tests to accommodate previous rename of default cluster image policy.