### PR TITLE
Make common method for retrieving kube client config

### DIFF
--- a/cmd/portieris/main.go
+++ b/cmd/portieris/main.go
@@ -63,12 +63,10 @@ func main() {
 		os.Exit(0)
 	}
 
-	kubeClientset := kube.GetKubeClient(kubeconfig)
+	kubeClientConfig := kube.GetKubeClientConfig(kubeconfig)
+	kubeClientset := kube.GetKubeClient(kubeClientConfig)
 	kubeWrapper := kubernetes.NewKubeClientsetWrapper(kubeClientset)
-	policyClient, err := kube.GetPolicyClient()
-	if err != nil {
-		glog.Fatal("Could not get policy client", err)
-	}
+	policyClient := kube.GetPolicyClient(kubeClientConfig)
 
 	ca, err := ioutil.ReadFile("/etc/certs/ca.pem")
 	if err != nil {


### PR DESCRIPTION
The same logic is used to retrieve the kube client config in the `GetKubeClient` and `GetPolicyClient` methods.  This change puts that logic into a common method in which the others can take advantage of.