### PR TITLE
nil pointer bug fix

### DIFF
--- a/helpers/kube/kube.go
+++ b/helpers/kube/kube.go
@@ -65,8 +65,6 @@ func GetKubeClientConfig(kubeconfigFileLoc *string) *rest.Config {
 
 // GetKubeClient creates a kube clientset
 func GetKubeClient(config *rest.Config) *kubernetes.Clientset {
-	var err error
-
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		glog.Fatal(err)
@@ -75,16 +73,11 @@ func GetKubeClient(config *rest.Config) *kubernetes.Clientset {
 }
 
 // GetPolicyClient creates a policy clientset
-func GetPolicyClient(*rest.Config) *policy.Client {
-	var config *rest.Config
-	var err error
-
-	// Get admission policy clientset
+func GetPolicyClient(config *rest.Config) *policy.Client {
 	clientset, err := securityenforcementclientset.NewForConfig(config)
 	if err != nil {
-		glog.Fatal("Could not get policy client", err)
+		glog.Fatal(err)
 	}
-
 	policyClient := policy.NewClient(clientset)
 	return policyClient
 }


### PR DESCRIPTION
Upon testing out these latest changes, I found the following nil pointer error:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x11ee3ba]

goroutine 1 [running]:
github.com/IBM/portieris/pkg/apis/securityenforcement/client/clientset/versioned.NewForConfig(0x0, 0x12a43df, 0xc0000f8200, 0xc0001b42c0)
	/go/src/github.com/IBM/portieris/pkg/apis/securityenforcement/client/clientset/versioned/clientset.go:59 +0x3a
github.com/IBM/portieris/helpers/kube.GetPolicyClient(0xc0000f8200, 0xc0003d0f40)
	/go/src/github.com/IBM/portieris/helpers/kube/kube.go:83 +0x2e
main.main()
	/go/src/github.com/IBM/portieris/cmd/portieris/main.go:69 +0x528
```