### PR TITLE
Explicit Helm install ordering only required on OpenShift, and breaks cleanup elsewhere

### DIFF
--- a/helm/portieris/templates/clusterrole.yaml
+++ b/helm/portieris/templates/clusterrole.yaml
@@ -8,8 +8,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
+    {{- if .Capabilities.APIVersions.Has "clusterversions.config.openshift.io" }}
     helm.sh/hook: pre-install
     helm.sh/hook-weight: "-10"
+    {{- end }}
 rules:
 - apiGroups: ["securityenforcement.admission.cloud.ibm.com"]
   resources: ["imagepolicies", "clusterimagepolicies"]

--- a/helm/portieris/templates/clusterrolebinding.yaml
+++ b/helm/portieris/templates/clusterrolebinding.yaml
@@ -8,8 +8,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
+    {{- if .Capabilities.APIVersions.Has "clusterversions.config.openshift.io" }}
     helm.sh/hook: pre-install
     helm.sh/hook-weight: "-9"
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/helm/portieris/templates/serviceaccount.yaml
+++ b/helm/portieris/templates/serviceaccount.yaml
@@ -13,5 +13,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
+    {{- if .Capabilities.APIVersions.Has "clusterversions.config.openshift.io" }}
     helm.sh/hook: pre-install
     helm.sh/hook-weight: "-7"
+    {{- end }}


### PR DESCRIPTION
The Portieris Helm chart doesn't always properly clean up installed resources - this is because we override the default Helm object creation logic with Helm preinstall hooks, and [as the Helm documentation states](https://helm.sh/docs/topics/charts_hooks/#hook-resources-are-not-managed-with-corresponding-releases), resources annotated with hooks are considered unmanaged by Helm and will not be removed on chart uninstall.

This annoyed me enough times to cause me to investigate, and I realized that we don't actually _need_ to muck with Helm's installation ordering for most cases - it already does the right thing, which is why the use of Helm hooks is generally discouraged in most cases.

The only time we need to override the default Helm behavior (and break chart resource cleanup) is if we're using OpenShift, which has a resource creation dependency limitation that doesn't play nice with Helm.

_If_ we're using OpenShift, we create an OShift-specific resource: `helm/portieris/templates/securitycontextconstraint.yaml` which breaks unless we force nonstandard Helm resource creation ordering.

To improve the chart removal process for everyone that isn't an OpenShift user, I wrapped the offending hooks in a conditional - this means that 

- if you **aren't** running on OpenShift, `helm install portieris/helm uninstall portieris` will do what you expect and clean up properly.
- if you **are** running on OpenShift, `helm install portieris/helm uninstall portieris` will do exactly what it does today, and force a nonstandard resource creation order as required by the OpenShift-specific `SecurityContextConstraints` custom resource, leaving orphaned resources on uninstall.