### PR TITLE
Make the ClusterImagePolicy a Helm variable, so it can easily be overridden by users

### DIFF
--- a/helm/portieris/templates/policies.yaml
+++ b/helm/portieris/templates/policies.yaml
@@ -72,6 +72,4 @@ metadata:
     helm.sh/hook-weight: "1"
 spec:
    repositories:
-    # This permissive policy allows all images in namespaces which do not have an ImagePolicy.
-    # IMPORTANT: Review this policy and replace it with one that meets your requirements.
-    - name: "*"
+   {{- .Values.clusterPolicy.allowedRepositories | toYaml | nindent 4 }}

--- a/helm/portieris/values.yaml
+++ b/helm/portieris/values.yaml
@@ -78,3 +78,9 @@ affinity:
 # setting the annotation on their namespaces. Therefore, be careful with your RBAC policies if you
 # enable this option!
 AllowAdmissionSkip: false
+
+clusterPolicy:
+  allowedRepositories:
+    # This permissive policy allows all images in namespaces which do not have an ImagePolicy.
+    # IMPORTANT: Review this policy and replace it with one that meets your requirements.
+    - name: "*"


### PR DESCRIPTION
Since we expect people to customize the default ClusterImagePolicy as an allowlist, it makes sense for it to be a Helm variable set in `values.yaml`, so that this value can be injected at installtime via the CLI, or overridden from a parent Helm chart.