### PR TITLE
Add additional validation to owner check

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1017,6 +1017,7 @@ k8s.io/apiextensions-apiserver v0.17.2/go.mod h1:4KdMpjkEjjDI2pPfBA15OscyNldHWdB
 k8s.io/apimachinery v0.17.2/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
 k8s.io/apimachinery v0.17.7 h1:1V+pxavZW+aYnjKzFi1yqvpdlDi396tnH6H7jkDgA20=
 k8s.io/apimachinery v0.17.7/go.mod h1:Lg8zZ5iC/O8UjCqW6DNhcQG2m4TdjF9kwG3891OWbbA=
+k8s.io/apimachinery v0.20.2 h1:hFx6Sbt1oG0n6DZ+g4bFt5f6BoMkOjKWsQFu077M3Vg=
 k8s.io/apiserver v0.17.2/go.mod h1:lBmw/TtQdtxvrTk0e2cgtOxHizXI+d0mmGQURIHQZlo=
 k8s.io/client-go v0.17.2/go.mod h1:QAzRgsa0C2xl4/eVpeVAZMvikCn8Nm81yqVx3Kk9XYI=
 k8s.io/client-go v0.17.7 h1:FjZwwd3WpTa1C1ZNTLg80g5cEhxHcxAvA1zQ5i8BhjE=

--- a/pkg/kubernetes/podspec.go
+++ b/pkg/kubernetes/podspec.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Portieris Authors.
+// Copyright 2018, 2021 Portieris Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kubernetes/podspec.go
+++ b/pkg/kubernetes/podspec.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Portieris Authors.
+// Copyright 2021 Portieris Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kubernetes/podspec.go
+++ b/pkg/kubernetes/podspec.go
@@ -49,14 +49,14 @@ var ErrObjectHasParents = fmt.Errorf("This object has parents")
 var ErrObjectHasZeroReplicas = fmt.Errorf("This object has zero replicas")
 
 var supportedKinds = map[string]struct{}{
-	"Deployment":            struct{}{},
-	"Pod":                   struct{}{},
-	"DaemonSet":             struct{}{},
-	"ReplicaSet":            struct{}{},
-	"ReplicationController": struct{}{},
-	"StatefulSet":           struct{}{},
-	"CronJob":               struct{}{},
-	"Job":                   struct{}{},
+	"Deployment":            {},
+	"Pod":                   {},
+	"DaemonSet":             {},
+	"ReplicaSet":            {},
+	"ReplicationController": {},
+	"StatefulSet":           {},
+	"CronJob":               {},
+	"Job":                   {},
 }
 
 // GetPodSpec retrieves the podspec from the admission request passed in

--- a/pkg/kubernetes/podspec.go
+++ b/pkg/kubernetes/podspec.go
@@ -258,9 +258,8 @@ func (w *Wrapper) decodeObject(raw []byte, object object) error {
 	for _, owner := range ownerRefs {
 		if _, ok := supportedKinds[owner.Kind]; ok {
 			return ErrObjectHasParents
-		} else {
-			glog.Warningf("Resource has an owner with a kind that is not supported: %s, treating this resource as top level", owner.Kind)
 		}
+		glog.Warningf("Resource has an owner with a kind that is not supported: %s, treating this resource as top level", owner.Kind)
 	}
 	return nil
 }

--- a/pkg/kubernetes/podspec_test.go
+++ b/pkg/kubernetes/podspec_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Portieris Authors.
+// Copyright 2018, 2021 Portieris Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kubernetes/podspec_test.go
+++ b/pkg/kubernetes/podspec_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Portieris Authors.
+// Copyright 2021 Portieris Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kubernetes/podspec_test.go
+++ b/pkg/kubernetes/podspec_test.go
@@ -764,7 +764,9 @@ func TestWrapper_mutateWithSA(t *testing.T) {
 }
 
 func TestWrapper_decodeObject(t *testing.T) {
-
+	pointerToBool := func(in bool) *bool {
+		return &in
+	}
 	tests := []struct {
 		name         string
 		raw          []byte
@@ -844,6 +846,35 @@ func TestWrapper_decodeObject(t *testing.T) {
 			object:       &corev1.Pod{},
 			wantErr:      true,
 			wantErrEqual: ErrObjectHasParents.Error(),
+		},
+		{
+			name:   "decodes a pod spec when it's owner of kind that we do not support",
+			raw:    []byte(`{"metadata":{"name":"nginx","namespace":"default","ownerReferences":[{"apiVersion":"customcontroller.v1","kind":"CustomController","name":"customercontroller-55d687c698","uid":"e0577bcf-30dd-11e8-83d1-baaf52c27f02","controller":true,"blockOwnerDeletion":true}]},"spec":{"containers":[{"name":"nginx","image":"docker.io/nginx"}]}}`),
+			object: &corev1.Pod{},
+			want: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nginx",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						metav1.OwnerReference{
+							APIVersion:         "customcontroller.v1",
+							Kind:               "CustomController",
+							Name:               "customercontroller-55d687c698",
+							UID:                "e0577bcf-30dd-11e8-83d1-baaf52c27f02",
+							Controller:         pointerToBool(true),
+							BlockOwnerDeletion: pointerToBool(true),
+						},
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "nginx",
+							Image: "docker.io/nginx",
+						},
+					},
+				},
+			},
 		},
 		{
 			name:    "returns error if the object is weird",

--- a/pkg/kubernetes/podspec_test.go
+++ b/pkg/kubernetes/podspec_test.go
@@ -848,7 +848,7 @@ func TestWrapper_decodeObject(t *testing.T) {
 			wantErrEqual: ErrObjectHasParents.Error(),
 		},
 		{
-			name:   "decodes a pod spec when it's owner of kind that we do not support",
+			name:   "decodes a pod spec when it's owner of a kind that we do not support",
 			raw:    []byte(`{"metadata":{"name":"nginx","namespace":"default","ownerReferences":[{"apiVersion":"customcontroller.v1","kind":"CustomController","name":"customercontroller-55d687c698","uid":"e0577bcf-30dd-11e8-83d1-baaf52c27f02","controller":true,"blockOwnerDeletion":true}]},"spec":{"containers":[{"name":"nginx","image":"docker.io/nginx"}]}}`),
 			object: &corev1.Pod{},
 			want: &corev1.Pod{
@@ -856,7 +856,7 @@ func TestWrapper_decodeObject(t *testing.T) {
 					Name:      "nginx",
 					Namespace: "default",
 					OwnerReferences: []metav1.OwnerReference{
-						metav1.OwnerReference{
+						{
 							APIVersion:         "customcontroller.v1",
 							Kind:               "CustomController",
 							Name:               "customercontroller-55d687c698",


### PR DESCRIPTION
After the change we would only return `ErrObjectHasParents` in the case the parent is of a supported kind.

Currently if a resource has an owner of any kind we do not admit as we expect the admission to happen at the owner level.

In the case where the owner is not a supported kind e.g. a CRD this leads to the resource being created with no admission occurring anywhere in the chain.

fixes: #246 