### PR TITLE
Add ability to specify a keySecret namespace that will override the one used by default

### DIFF
--- a/cmd/portieris/main.go
+++ b/cmd/portieris/main.go
@@ -39,6 +39,7 @@ import (
 func main() {
 	mkdir := flag.String("mkdir", "", "create directories needed for Portieris to run")
 	kubeconfig := flag.String("kubeconfig", "", "location of kubeconfig file to use for an out-of-cluster kube client configuration")
+	imageSigningPublicKeySecretNamespace := flag.String("pubkey-secret-namespace-override", "", "specify a namespace that will override where to look for the image signing public key secret")
 
 	flag.Parse() // glog flags
 
@@ -95,7 +96,7 @@ func main() {
 	cr := registryclient.NewClient()
 	nv := notaryverifier.NewVerifier(kubeWrapper, trust, cr)
 	pmetrics := metrics.NewMetrics()
-	controller := multi.NewController(kubeWrapper, policyClient, nv, pmetrics)
+	controller := multi.NewController(kubeWrapper, policyClient, nv, pmetrics, *imageSigningPublicKeySecretNamespace)
 
 	// Setup http handler for metrics
 	go func() {

--- a/pkg/controller/multi/controller.go
+++ b/pkg/controller/multi/controller.go
@@ -49,8 +49,8 @@ type Controller struct {
 }
 
 // NewController creates a new controller object from the various clients passed in
-func NewController(kubeWrapper kubernetes.WrapperInterface, policyClient policy.Interface, nv *notaryverifier.Verifier, pm *metrics.PortierisMetrics) *Controller {
-	enforcer := NewEnforcer(kubeWrapper, nv)
+func NewController(kubeWrapper kubernetes.WrapperInterface, policyClient policy.Interface, nv *notaryverifier.Verifier, pm *metrics.PortierisMetrics, imageSigningPublicKeySecretNamespace string) *Controller {
+	enforcer := NewEnforcer(kubeWrapper, nv, imageSigningPublicKeySecretNamespace)
 	return &Controller{
 		kubeClientsetWrapper: kubeWrapper,
 		policyClient:         policyClient,

--- a/pkg/controller/multi/controller_test.go
+++ b/pkg/controller/multi/controller_test.go
@@ -104,7 +104,7 @@ func TestNewController(t *testing.T) {
 		PMetrics:             wantMetrics,
 	}
 
-	gotController := NewController(wantKubeWrapper, wantPolicyClient, wantNV, wantMetrics)
+	gotController := NewController(wantKubeWrapper, wantPolicyClient, wantNV, wantMetrics, "")
 
 	assert.Equal(t, wantController, *gotController)
 }

--- a/pkg/controller/multi/notary_suite_test.go
+++ b/pkg/controller/multi/notary_suite_test.go
@@ -84,7 +84,7 @@ func resetAllFakes() {
 	trust = &fakenotary.FakeNotary{}
 	cr = &fakeregistry.FakeRegistry{}
 	nv := notaryverifier.NewVerifier(kubeWrapper, trust, cr)
-	ctrl = NewController(kubeWrapper, policyClient, nv, pm)
+	ctrl = NewController(kubeWrapper, policyClient, nv, pm, "")
 	wh = webhook.NewServer("notary", ctrl, []byte{}, []byte{})
 }
 

--- a/pkg/controller/multi/notary_test.go
+++ b/pkg/controller/multi/notary_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Main", func() {
 
 		updateController := func() {
 			nv := notaryverifier.NewVerifier(kubeWrapper, trust, cr)
-			ctrl = NewController(kubeWrapper, policyClient, nv, pm)
+			ctrl = NewController(kubeWrapper, policyClient, nv, pm, "")
 			wh = webhook.NewServer("notary", ctrl, []byte{}, []byte{})
 		}
 


### PR DESCRIPTION
ex. --pubkey-secret-namespace-override default

Specifying the above CLI flag at Portieris startup will cause Portieris to
look for the image signing public key secret in the "default" namespace, rather than
the namespace of the image being admitted.  This way, the secret does not have to be replicated
to all namespaces in a cluster where images are to have their signatures enforced.

Addresses https://github.com/IBM/portieris/issues/245