### PR TITLE
Add keySecretNamespace policy option

### DIFF
--- a/helm/portieris/crds/crds.yaml
+++ b/helm/portieris/crds/crds.yaml
@@ -73,6 +73,8 @@ spec:
                                       enum: [ "insecureAcceptAnything", "reject", "signedBy" ]
                                     keySecret:
                                       type: string
+                                    keySecretNamespace:
+                                      type: string
                                     signedIdentity:
                                       type: object
                                       required: [ "type" ]
@@ -168,6 +170,8 @@ spec:
                                       type: string
                                       enum: [ "insecureAcceptAnything", "reject", "signedBy" ]
                                     keySecret:
+                                      type: string
+                                    keySecretNamespace:
                                       type: string
                                     signedIdentity:
                                       type: object

--- a/pkg/apis/portieris.cloud.ibm.com/v1/types.go
+++ b/pkg/apis/portieris.cloud.ibm.com/v1/types.go
@@ -118,9 +118,10 @@ type Simple struct {
 
 // SimpleRequirement .
 type SimpleRequirement struct {
-	Type           string              `json:"type"`
-	KeySecret      string              `json:"keySecret,omitEmpty"`
-	SignedIdentity IdentityRequirement `json:"signedIdentity,omitEmpty"`
+	Type               string              `json:"type"`
+	KeySecret          string              `json:"keySecret,omitEmpty"`
+	KeySecretNamespace string              `json:"keySecretNamespace,omitEmpty"`
+	SignedIdentity     IdentityRequirement `json:"signedIdentity,omitEmpty"`
 }
 
 // IdentityRequirement .

--- a/pkg/verifier/simple/policy.go
+++ b/pkg/verifier/simple/policy.go
@@ -43,7 +43,12 @@ func (v verifier) TransformPolicies(kWrapper kubernetes.WrapperInterface, namesp
 				return nil, fmt.Errorf("KeySecret missing in signedBy requirement")
 			}
 
-			secretBytes, err := kWrapper.GetSecretKey(namespace, inPolicy.KeySecret)
+			secretNamespace := namespace
+			// Override the default namespace behavior if a namespace was provided in this policy
+			if inPolicy.KeySecretNamespace != "" {
+				secretNamespace = inPolicy.KeySecretNamespace
+			}
+			secretBytes, err := kWrapper.GetSecretKey(secretNamespace, inPolicy.KeySecret)
 			if err != nil {
 				return nil, err
 			}

--- a/test/e2e/policy.generic_test.go
+++ b/test/e2e/policy.generic_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Portieris Authors.
+// Copyright 2018, 2021 Portieris Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,55 +25,55 @@ func Test_JobTypesSuccess(t *testing.T) {
 
 	t.Run("Policy enforced on Deployment", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml", "")
 		utils.TestDeploymentRunnable(t, framework, "./testdata/deployment/global-nginx-signed.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 	t.Run("Policy enforced on DaemonSet", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml", "")
 		utils.TestDaemonSetRunnable(t, framework, "./testdata/daemonset/global-nginx-signed.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 
 	t.Run("Policy enforced on ReplicaSet", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml", "")
 		utils.TestReplicaSetRunnable(t, framework, "./testdata/replicaset/global-nginx-signed.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 
 	t.Run("Policy enforced on ReplicationController", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml", "")
 		utils.TestReplicationControllerRunnable(t, framework, "./testdata/replicationcontroller/global-nginx-signed.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 
 	t.Run("Policy enforced on Pod", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml", "")
 		utils.TestPodRunnable(t, framework, "./testdata/pod/global-nginx-signed.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 
 	t.Run("Policy enforced on StatefulSet", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml", "")
 		utils.TestStatefulSetRunnable(t, framework, "./testdata/statefulset/global-nginx-signed.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 
 	t.Run("Policy enforced on Job", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml", "")
 		utils.TestJobRunnable(t, framework, "./testdata/job/global-nginx-signed.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 
 	t.Run("Policy enforced on CronJob", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml", "")
 		utils.TestCronJobRunnable(t, framework, "./testdata/cronjob/global-nginx-signed.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
@@ -85,55 +85,55 @@ func Test_JobTypesSuccess(t *testing.T) {
 
 	t.Run("Policy enforced on Deployment", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml", "")
 		utils.TestDeploymentRunnable(t, framework, "./testdata/deployment/global-nginx-signed.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 	t.Run("Policy enforced on DaemonSet", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml", "")
 		utils.TestDaemonSetRunnable(t, framework, "./testdata/daemonset/global-nginx-signed.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 
 	t.Run("Policy enforced on ReplicaSet", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml", "")
 		utils.TestReplicaSetRunnable(t, framework, "./testdata/replicaset/global-nginx-signed.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 
 	t.Run("Policy enforced on ReplicationController", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml", "")
 		utils.TestReplicationControllerRunnable(t, framework, "./testdata/replicationcontroller/global-nginx-signed.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 
 	t.Run("Policy enforced on Pod", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml", "")
 		utils.TestPodRunnable(t, framework, "./testdata/pod/global-nginx-signed.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 
 	t.Run("Policy enforced on StatefulSet", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml", "")
 		utils.TestStatefulSetRunnable(t, framework, "./testdata/statefulset/global-nginx-signed.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 
 	t.Run("Policy enforced on Job", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml", "")
 		utils.TestJobRunnable(t, framework, "./testdata/job/global-nginx-signed.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 
 	t.Run("Policy enforced on CronJob", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml", "")
 		utils.TestCronJobRunnable(t, framework, "./testdata/cronjob/global-nginx-signed.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
@@ -144,49 +144,49 @@ func Test_JobTypesSuccess(t *testing.T) {
 
 	t.Run("Policy enforced on Deployment", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml", "")
 		utils.TestDeploymentNotRunnable(t, framework, "./testdata/deployment/global-nginx-unsigned.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 	t.Run("Policy enforced on DaemonSet", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml", "")
 		utils.TestDaemonSetNotRunnable(t, framework, "./testdata/daemonset/global-nginx-unsigned.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 	t.Run("Policy enforced on ReplicaSet", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml", "")
 		utils.TestReplicaSetNotRunnable(t, framework, "./testdata/replicaset/global-nginx-unsigned.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 	t.Run("Policy enforced on ReplicationController", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml", "")
 		utils.TestReplicationControllerNotRunnable(t, framework, "./testdata/replicationcontroller/global-nginx-unsigned.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 	t.Run("Policy enforced on Pod", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml", "")
 		utils.TestPodNotRunnable(t, framework, "./testdata/pod/global-nginx-unsigned.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 	t.Run("Policy enforced on StatefulSet", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml", "")
 		utils.TestStatefulSetNotRunnable(t, framework, "./testdata/statefulset/global-nginx-unsigned.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 	t.Run("Policy enforced on Job", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml", "")
 		utils.TestJobNotRunnable(t, framework, "./testdata/job/global-nginx-unsigned.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 	t.Run("Policy enforced on CronJob", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed-custom.yaml", "")
 		utils.TestCronJobNotRunnable(t, framework, "./testdata/cronjob/global-nginx-unsigned.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
@@ -198,49 +198,49 @@ func Test_JobTypesFail(t *testing.T) {
 
 	t.Run("Policy enforced on Deployment", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml", "")
 		utils.TestDeploymentNotRunnable(t, framework, "./testdata/deployment/global-nginx-unsigned.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 	t.Run("Policy enforced on DaemonSet", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml", "")
 		utils.TestDaemonSetNotRunnable(t, framework, "./testdata/daemonset/global-nginx-unsigned.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 	t.Run("Policy enforced on ReplicaSet", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml", "")
 		utils.TestReplicaSetNotRunnable(t, framework, "./testdata/replicaset/global-nginx-unsigned.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 	t.Run("Policy enforced on ReplicationController", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml", "")
 		utils.TestReplicationControllerNotRunnable(t, framework, "./testdata/replicationcontroller/global-nginx-unsigned.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 	t.Run("Policy enforced on Pod", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml", "")
 		utils.TestPodNotRunnable(t, framework, "./testdata/pod/global-nginx-unsigned.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 	t.Run("Policy enforced on StatefulSet", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml", "")
 		utils.TestStatefulSetNotRunnable(t, framework, "./testdata/statefulset/global-nginx-unsigned.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 	t.Run("Policy enforced on Job", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml", "")
 		utils.TestJobNotRunnable(t, framework, "./testdata/job/global-nginx-unsigned.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 	t.Run("Policy enforced on CronJob", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml", "")
 		utils.TestCronJobNotRunnable(t, framework, "./testdata/cronjob/global-nginx-unsigned.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
@@ -253,7 +253,7 @@ func Test_OperationsSucces(t *testing.T) {
 	t.Run("Policy not enforced on child resource (pod)", func(t *testing.T) {
 		t.Parallel()
 		// Create namespace and policy to allow all
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-all.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-all.yaml", "")
 		//Start deployment
 		deploymentName := utils.TestStartDeployNoDelete(t, framework, "./testdata/deployment/global-nginx-unsigned.yaml", namespace.Name)
 		// Change policy to deny
@@ -282,7 +282,7 @@ func Test_OperationsSucces(t *testing.T) {
 			}
 		 }`
 		// Create namespace and policy to allow all
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml", "")
 		//Start deployment
 		deploymentName := utils.TestStartDeployNoDelete(t, framework, "./testdata/deployment/global-nginx-signed.yaml", namespace.Name)
 		// Change policy to deny
@@ -294,7 +294,7 @@ func Test_OperationsSucces(t *testing.T) {
 	t.Run("Policy enforced on replace", func(t *testing.T) {
 		t.Parallel()
 		// Create namespace and policy to allow all
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-signed.yaml", "")
 		//Start deployment
 		_ = utils.TestStartDeployNoDelete(t, framework, "./testdata/deployment/global-nginx-signed.yaml", namespace.Name)
 		// Change policy to deny

--- a/test/e2e/simple.imagePolicy_test.go
+++ b/test/e2e/simple.imagePolicy_test.go
@@ -28,7 +28,7 @@ func TestSimple_ImagePolicyRepositories_AllowAllDenyAll(t *testing.T) {
 
 	t.Run("Allow all images", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/simple-accept-anything.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/simple-accept-anything.yaml", "")
 		utils.TestDeploymentRunnable(t, framework, "./testdata/deployment/global-nginx-unsigned.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
@@ -47,14 +47,14 @@ func TestSimple_ImagePolicyRepositories_Basic(t *testing.T) {
 	utils.CheckIfTesting(t, testSimpleImagePolicy)
 	t.Run("Allow images signed by the correct single simple signer", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/simple-signedby1.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/simple-signedby1.yaml", "")
 		utils.CreateSecret(t, framework, "./testdata/secret/simple1pubkey.yaml", namespace.Name)
 		utils.TestDeploymentRunnable(t, framework, "./testdata/deployment/global-nginx-simple.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 	t.Run("Allow images signed the correct multiple simple signers", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/simple-signedby2.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/simple-signedby2.yaml", "")
 		utils.CreateSecret(t, framework, "./testdata/secret/simple1pubkey.yaml", namespace.Name)
 		utils.CreateSecret(t, framework, "./testdata/secret/simple2pubkey.yaml", namespace.Name)
 		utils.TestDeploymentRunnableCheck(t, framework, "./testdata/deployment/global-nginx-simple.yaml", namespace.Name, utils.VerifySha)
@@ -62,7 +62,7 @@ func TestSimple_ImagePolicyRepositories_Basic(t *testing.T) {
 	})
 	t.Run("Allow images signed the correct multiple simple signers with no mutation", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/simple-signedby2-nomutate.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/simple-signedby2-nomutate.yaml", "")
 		utils.CreateSecret(t, framework, "./testdata/secret/simple1pubkey.yaml", namespace.Name)
 		utils.CreateSecret(t, framework, "./testdata/secret/simple2pubkey.yaml", namespace.Name)
 		utils.TestDeploymentRunnableCheck(t, framework, "./testdata/deployment/global-nginx-simple.yaml", namespace.Name, utils.VerifyNoSha)
@@ -70,22 +70,29 @@ func TestSimple_ImagePolicyRepositories_Basic(t *testing.T) {
 	})
 	t.Run("Allow images signed the correct multiple simple signers with explicit mutation", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/simple-signedby2-mutate.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/simple-signedby2-mutate.yaml", "")
 		utils.CreateSecret(t, framework, "./testdata/secret/simple1pubkey.yaml", namespace.Name)
 		utils.CreateSecret(t, framework, "./testdata/secret/simple2pubkey.yaml", namespace.Name)
 		utils.TestDeploymentRunnableCheck(t, framework, "./testdata/deployment/global-nginx-simple.yaml", namespace.Name, utils.VerifySha)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
+	t.Run("Allow images signed by the correct single simple signer with a secret namespace override", func(t *testing.T) {
+		t.Parallel()
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/simple-signedby1-keysecret-namespace-override.yaml", "secretnamespace")
+		utils.CreateSecret(t, framework, "./testdata/secret/simple1pubkey.yaml", namespace.Name)
+		utils.TestDeploymentRunnableCheck(t, framework, "./testdata/deployment/global-nginx-simple.yaml", namespace.Name, utils.VerifySha)
+		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
+	})
 	t.Run("Deny images signed by the wrong single simple signer", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/simple-signedby1.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/simple-signedby1.yaml", "")
 		utils.CreateSecret(t, framework, "./testdata/secret/simple1pubkey.yaml", namespace.Name)
 		utils.TestDeploymentNotRunnable(t, framework, "./testdata/deployment/global-nginx-another.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 	t.Run("Deny images signed by a single simple signer when multiple are required", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/simple-signedby2.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/simple-signedby2.yaml", "")
 		utils.CreateSecret(t, framework, "./testdata/secret/simple1pubkey.yaml", namespace.Name)
 		utils.CreateSecret(t, framework, "./testdata/secret/simple2pubkey.yaml", namespace.Name)
 		utils.TestDeploymentNotRunnable(t, framework, "./testdata/deployment/global-nginx-another.yaml", namespace.Name)
@@ -93,7 +100,7 @@ func TestSimple_ImagePolicyRepositories_Basic(t *testing.T) {
 	})
 	t.Run("Allow images matched with remapIdentity policy", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/simple-remap.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/simple-remap.yaml", "")
 		utils.CreateSecret(t, framework, "./testdata/secret/simple1pubkey.yaml", namespace.Name)
 		utils.TestDeploymentRunnable(t, framework, "./testdata/deployment/global-nginx-remapped.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)

--- a/test/e2e/testdata/imagepolicy/simple-signedby1-keysecret-namespace-override.yaml
+++ b/test/e2e/testdata/imagepolicy/simple-signedby1-keysecret-namespace-override.yaml
@@ -1,0 +1,16 @@
+apiVersion: portieris.cloud.ibm.com/v1
+kind: ImagePolicy
+metadata:
+  name: simple-signedby1
+spec:
+   repositories:
+    - name: "icr.io/cise/*"
+      policy:
+         simpleStore:
+            url: "https://foo.com/x"
+            auth: storesecret 
+         simple:
+           requirements:
+           - type: "signedBy"
+             keySecret: simple1pubkey
+             keySecretNamespace: secretnamespace

--- a/test/e2e/utils/imagepolicy.go
+++ b/test/e2e/utils/imagepolicy.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Portieris Authors.
+// Copyright 2020, 2021 Portieris Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,8 +25,11 @@ import (
 )
 
 // CreateImagePolicyInstalledNamespaceOptionalSecrets ...
-func CreateImagePolicyInstalledNamespaceOptionalSecrets(t *testing.T, fw *framework.Framework, manifestPath string, ips bool) *corev1.Namespace {
+func CreateImagePolicyInstalledNamespaceOptionalSecrets(t *testing.T, fw *framework.Framework, manifestPath string, ips bool, namespaceParam string) *corev1.Namespace {
 	ns := uuid.NewV4().String()
+	if namespaceParam != "" {
+		ns = namespaceParam
+	}
 	imagePolicy, err := fw.LoadImagePolicyManifest(manifestPath)
 	if err != nil {
 		t.Fatalf("error loading %q ImagePolicy manifest: %v", manifestPath, err)
@@ -62,13 +65,13 @@ func CreateImagePolicyInstalledNamespaceOptionalSecrets(t *testing.T, fw *framew
 }
 
 // CreateImagePolicyInstalledNamespace ...
-func CreateImagePolicyInstalledNamespace(t *testing.T, fw *framework.Framework, manifestPath string) *corev1.Namespace {
-	return CreateImagePolicyInstalledNamespaceOptionalSecrets(t, fw, manifestPath, true)
+func CreateImagePolicyInstalledNamespace(t *testing.T, fw *framework.Framework, manifestPath string, ns string) *corev1.Namespace {
+	return CreateImagePolicyInstalledNamespaceOptionalSecrets(t, fw, manifestPath, true, ns)
 }
 
 // CreateImagePolicyInstalledNamespaceNoSecrets ...
 func CreateImagePolicyInstalledNamespaceNoSecrets(t *testing.T, fw *framework.Framework, manifestPath string) *corev1.Namespace {
-	return CreateImagePolicyInstalledNamespaceOptionalSecrets(t, fw, manifestPath, false)
+	return CreateImagePolicyInstalledNamespaceOptionalSecrets(t, fw, manifestPath, false, "")
 }
 
 // CleanUpImagePolicyTest ...

--- a/test/e2e/vulnerability.imagePolicy_test.go
+++ b/test/e2e/vulnerability.imagePolicy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020  Portieris Authors.
+// Copyright 2020, 2021  Portieris Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,30 +29,30 @@ func Test_ICCRVA_ImagePolicy(t *testing.T) {
 	t.Run("Pods are admitted when ICCRVA is enabled when VA results are OK", func(t *testing.T) {
 		t.Parallel()
 		// this pod spec references an image with UNSUPPORTED status.
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/vulnerability-enabled.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/vulnerability-enabled.yaml", "")
 		utils.TestDeploymentRunnable(t, framework, "./testdata/deployment/vulnerability-allow.yaml", namespace.Name)
 	})
 	t.Run("Pods are denied when ICCRVA is enabled when VA results are not OK", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/vulnerability-enabled.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/vulnerability-enabled.yaml", "")
 		utils.TestDeploymentNotRunnable(t, framework, "./testdata/deployment/vulnerability-deny.yaml", namespace.Name)
 	})
 	t.Run("Pods that are admissable by simple signing, are denied when VA status is not OK", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/vulnerability-enabled-with-simple.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/vulnerability-enabled-with-simple.yaml", "")
 		utils.CreateSecret(t, framework, "./testdata/secret/simple1pubkey.yaml", namespace.Name)
 		utils.TestDeploymentNotRunnable(t, framework, "./testdata/deployment/vulnerability-deny-vulnerable-signed.yaml", namespace.Name)
 	})
 	t.Run("Pods are not admitted when they have non-exempted config issues", func(t *testing.T) {
 		t.Parallel()
 		// this pod spec references an image with configuration issues.
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/vulnerability-enabled.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/vulnerability-enabled.yaml", "")
 		utils.TestDeploymentNotRunnable(t, framework, "./testdata/deployment/vulnerability-account-exemption.yaml", namespace.Name)
 	})
 	t.Run("Pods are admitted when exemptions from a specified account make the image safe to deploy", func(t *testing.T) {
 		t.Parallel()
 		// this test requires you to export E2E_ACCOUNT_HEADER to an account which has exempted the configuration issue:
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/vulnerability-with-account.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/vulnerability-with-account.yaml", "")
 		utils.TestDeploymentRunnable(t, framework, "./testdata/deployment/vulnerability-account-exemption.yaml", namespace.Name)
 	})
 

--- a/test/e2e/wildcard.generic_test.go
+++ b/test/e2e/wildcard.generic_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Portieris Authors.
+// Copyright 2018, 2021 Portieris Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,19 +28,19 @@ func TestWildcards_ImagePolicyRepositories_Wildcards(t *testing.T) {
 
 	t.Run("Correctly apply policy when single trailing wildcard is used", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-unsigned-trailing-wildcard.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-unsigned-trailing-wildcard.yaml", "")
 		utils.TestDeploymentRunnable(t, framework, "./testdata/deployment/global-nginx-unsigned.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 	t.Run("Correctly apply policy when single embedded wildcard is used", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-unsigned-embedded-wildcard.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-unsigned-embedded-wildcard.yaml", "")
 		utils.TestDeploymentRunnable(t, framework, "./testdata/deployment/global-nginx-unsigned.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})
 	t.Run("Correctly apply policy when both embedded and trailing wildcard are used", func(t *testing.T) {
 		t.Parallel()
-		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-unsigned-embedded-trailing-wildcard.yaml")
+		namespace := utils.CreateImagePolicyInstalledNamespace(t, framework, "./testdata/imagepolicy/allow-unsigned-embedded-trailing-wildcard.yaml", "")
 		utils.TestDeploymentRunnable(t, framework, "./testdata/deployment/global-nginx-unsigned.yaml", namespace.Name)
 		utils.CleanUpImagePolicyTest(t, framework, namespace.Name)
 	})


### PR DESCRIPTION
This gives the ability to specify a namespace to look for the secret
specified in the `keySecret` field that will override the default behavior of just
looking in the namespace of the image being admitted.