### PR TITLE
Add secrets baseline and pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+# This is an example configuration to enable detect-secrets in the pre-commit hook.
+# Add this file to the root folder of your repository.
+#
+# Read pre-commit hook framework https://pre-commit.com/ for more details about the structure of config yaml file and how git pre-commit would invoke each hook.
+#
+# This line indicates we will use the hook from ibm/detect-secrets to run scan during committing phase.
+# Whitewater/whitewater-detect-secrets would sync code to ibm/detect-secrets upon merge.
+- repo: https://github.com/ibm/detect-secrets
+  # If you desire to use a specific version of detect-secrets, you can replace `master` with other git revisions such as branch, tag or commit sha.
+  # You are encouraged to use static refs such as tags, instead of branch name
+  #
+  # Running "pre-commit autoupdate" would automatically updates rev to latest tag
+  rev: master
+  hooks:
+    - id: detect-secrets # pragma: whitelist secret
+      # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.
+      # You may also run `pre-commit run detect-secrets` to preview the scan result.
+      # when "--baseline" without "--use-all-plugins", pre-commit scan with just plugins in baseline file
+      # when "--baseline" with "--use-all-plugins", pre-commit scan with all available plugins
+      # add "--fail-on-non-audited" to fail pre-commit for unaudited potential secrets
+      args: [--baseline, .secrets.baseline, --use-all-plugins ]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,633 @@
+{
+  "exclude": {
+    "files": "go.*|^.secrets.baseline$",
+    "lines": null
+  },
+  "generated_at": "2021-03-03T14:29:09Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "GheDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "POLICIES.md": [
+      {
+        "hashed_secret": "ad5781cc8192e1e8247b3174bb14b2177c16d71c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 143,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "05baadf86b23d3dafaf432263a7cf24d0287a350",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 200,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "13010f67cb54ac2a32bc6c4a5a7ab38133a11fa8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 203,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "test/e2e/testdata/imagepolicy/simple-remap.yaml": [
+      {
+        "hashed_secret": "842aead05193389c5dcae32d145726af222a1d8e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 12,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "test/e2e/testdata/imagepolicy/simple-signedby1-keysecret-namespace-override.yaml": [
+      {
+        "hashed_secret": "842aead05193389c5dcae32d145726af222a1d8e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 15,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "test/e2e/testdata/imagepolicy/simple-signedby1.yaml": [
+      {
+        "hashed_secret": "842aead05193389c5dcae32d145726af222a1d8e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 15,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "test/e2e/testdata/imagepolicy/simple-signedby2-mutate.yaml": [
+      {
+        "hashed_secret": "842aead05193389c5dcae32d145726af222a1d8e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 13,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fc27e33f1b1d99c6ea1b257978ae7082ac11305d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 15,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "test/e2e/testdata/imagepolicy/simple-signedby2-nomutate.yaml": [
+      {
+        "hashed_secret": "842aead05193389c5dcae32d145726af222a1d8e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 13,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fc27e33f1b1d99c6ea1b257978ae7082ac11305d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 15,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "test/e2e/testdata/imagepolicy/simple-signedby2.yaml": [
+      {
+        "hashed_secret": "842aead05193389c5dcae32d145726af222a1d8e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 12,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fc27e33f1b1d99c6ea1b257978ae7082ac11305d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 14,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "test/e2e/testdata/imagepolicy/vulnerability-enabled-with-simple.yaml": [
+      {
+        "hashed_secret": "842aead05193389c5dcae32d145726af222a1d8e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 12,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "test/e2e/testdata/secret/signer1.pubkey.yaml": [
+      {
+        "hashed_secret": "c7ab34786143ff262890ec177a9f8526e7b36d2f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 8,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "test/e2e/testdata/secret/signer2.pubkey.yaml": [
+      {
+        "hashed_secret": "5859c77546a1d055b9eef100701fd35d44283cea",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 8,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "test/e2e/testdata/secret/simple1pubkey.yaml": [
+      {
+        "hashed_secret": "cd39e6265d9bd44575212d8a4e9a014308404388",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 10,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7aa93476686287c401da6cc2bd345b7ae94d6031",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 11,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f8e89ad7a4590c3c7c8122f998a4fd2f0319edd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 12,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1a62217eab258e522d44527b4af16a1d9d5a28d0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 13,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "445b8d70748a79c9412e711bb523505ec352e471",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 14,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e3139e40c9680e138e60b362ec556848db7c8834",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 15,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "74407d1bbd30a660f87282c709cc438a61ff27ad",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 16,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f26c24e32ebf55db999d635f4746b205c19666f5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 17,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4b92f77a953245d82def2904518d28d219180300",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9ba11eff66d3fa1127cb624fa80b5fa4d8d980a8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ccc81be13f42407247584b65f9a6ed025c61ecee",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 20,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3f01bee625dc145df3c3b0a7a7414af342aa5368",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 21,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0528de28032175e4cf3933811f204fcc2e7e2a3a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0eacafadce2cfb82d797e1a5957a922c661593d3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4b7cdb2f35d466fec36a67d60be202f659a16fcd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 24,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6ff1d9ab57dfd41fe67ccf1106dd50d287c7dcf8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7ee14e5ef898eef68f1ed475c1efe2f016ab6fd6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 26,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "41f23376b6a4a6281cac3885ed2a0e754f591dfe",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 27,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b6a26eef749da18c7e53986d5aeed0349f4efd6e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 28,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a639f2898c8d21b87b5fb49145b9b2ea822b89c6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 29,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e4bb149892819f39abf5f4df6028fb4c00890df8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b7625d737e7ab9f4bc84d3e48d9a447a688d5cb6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 31,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1046c12e10b07a9cd698f9214438984b5bf929b9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 32,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "aab194299d0dec2420f00e52f81a85c238a63f07",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 33,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bf45850845c9c3252d698129317da0cd00bd6ba2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 34,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f86106600327fc65e97e582f83240d92b0a59a51",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 35,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "test/e2e/testdata/secret/simple2pubkey.yaml": [
+      {
+        "hashed_secret": "bf4856a6ad8d90ee97188f32517705ece1456f6e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 10,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6487094d1081d17a1d79040751c3ddd92ae65972",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 11,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "80a9ef72d75b5c9f0c83ffe4c764cc2ab6607fe0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 12,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d37528be6557206074aff56ea2b5f17c8127e344",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 13,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "84de95f8d08626d48c5699fef922ce87a2d54a69",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 14,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7f03904f3d87931f9423f2223f85ec0c334023f0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 15,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2b6acbd3ffbca5608b8a2632d93b7a90d46ef84a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 16,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "53e35238f92c63024d63055ebb7b3bdd4d67771c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 17,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "95d8159b93e0bd99943c5bcd34ea8b3cbd2dea6d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "23323064a098a8ef24bc3b7ac7942abf2f4a24bb",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d1223bc9069b2b9c5c648f49e41a272c65619bf2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 20,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0d8f424499c03a217cd1edfb766e4bdd1916d090",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 21,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "585aa8dc68070839ae255c545df7e42c9514ec3a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1f7e9b7398336fd3d9bcad9555438a8d8cec0800",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "233b6689b88c870c5a91a9f2575f41216227f085",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 24,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "776e0995667afb85c3ea13191c2a41983f60f653",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "14fda8bc73ce4c89d23aa2c4f5f4f2cf89dcdaeb",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 26,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3543b1926a1f40cb304325b5a6ca262ac121643b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 27,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9710cc63892a932df567b2fd0868931541faa657",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 28,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6e0753c2432d89a5c98c67debccc8a9f37ee6801",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 29,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "eecbd53b849ce17279f7d48ad78f0624a4acdfe2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b891fdde2b169c903d747333053082dc948d7d90",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 31,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "10452d09d0db6913342f78580ee4dd5184797f82",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 32,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "89cbe260a22b2b691da7507328687c45c62771b0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 33,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f6d2e89db0bd2a6a05dbd98185745ca33d29481b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 34,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5df509de4de3a9148453e67e60a813ba2b0b031b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 35,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.29.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}


### PR DESCRIPTION
Signed-off-by: James Hart <jhart@uk.ibm.com>
Secrets marked as false positives:
- In POLICIES.md - they are strings like `keySecret: my-pubkey` , which are not secrets.
- In e2e test framework, there are some public keys, which are permitted (as they are public).