### PR TITLE
added hostnetwork option to values and deployment.yaml

### DIFF
--- a/helm/portieris/templates/deployment.yaml
+++ b/helm/portieris/templates/deployment.yaml
@@ -26,6 +26,7 @@ spec:
       serviceAccountName: portieris
       {{- if .Values.useHostNetwork }}
       hostNetwork: true  
+      dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/helm/portieris/templates/deployment.yaml
+++ b/helm/portieris/templates/deployment.yaml
@@ -24,6 +24,9 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: portieris
+      {{- if .Values.useHostNetwork }}
+      hostNetwork: true  
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.host | default "docker.io/ibmcom"  }}/{{ .Values.image.image }}:{{ .Values.image.tag }}"

--- a/helm/portieris/values.yaml
+++ b/helm/portieris/values.yaml
@@ -84,3 +84,6 @@ clusterPolicy:
     # This permissive policy allows all images in namespaces which do not have an ImagePolicy.
     # IMPORTANT: Review this policy and replace it with one that meets your requirements.
     - name: "*"
+
+# use hostNetwork for Portieris webhook
+useHostNetwork: false


### PR DESCRIPTION
- add useHostNetwork value to the values.yaml, default to false
- use the value in deployment.yaml to set hostNetwork: true for the deployment

helm template meow ./portieris/ --set useHostNetwork=true
```
    spec:
      serviceAccountName: portieris
      hostNetwork: true
      dnsPolicy: ClusterFirstWithHostNet
      containers:
        - name: portieris
          image: "icr.io/portieris/portieris:v0.10.1"
          imagePullPolicy: Always
          ports:
```

if useHostNetwork=false or just not --set
```
    spec:
      serviceAccountName: portieris
      containers:
        - name: portieris
          image: "icr.io/portieris/portieris:v0.10.1"
          imagePullPolicy: Always
          ports:
```
