### PR TITLE
v1 hook should return a v1 result

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,6 @@ require (
 	github.com/IBM/go-sdk-core/v4 v4.9.0
 	github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d // indirect
 	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect
-	github.com/bitly/go-hostpool v0.1.0 // indirect
-	github.com/bitly/go-simplejson v0.5.0 // indirect
-	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/bugsnag/bugsnag-go v1.5.3 // indirect
 	github.com/bugsnag/panicwrap v1.2.0 // indirect
 	github.com/cloudflare/cfssl v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,13 +65,7 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
-github.com/bitly/go-hostpool v0.1.0 h1:XKmsF6k5el6xHG3WPJ8U0Ku/ye7njX7W81Ng7O2ioR0=
-github.com/bitly/go-hostpool v0.1.0/go.mod h1:4gOCgp6+NZnVqlKyZ/iBZFTAJKembaVENUpMkpg42fw=
-github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=
-github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
-github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bugsnag/bugsnag-go v1.5.3 h1:yeRUT3mUE13jL1tGwvoQsKdVbAsQx9AJ+fqahKveP04=
 github.com/bugsnag/bugsnag-go v1.5.3/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/panicwrap v1.2.0 h1:OzrKrRvXis8qEvOkfcxNcYbOd2O7xXS2nnKMEMABFQA=
@@ -133,7 +127,6 @@ github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd h1:83Wprp6ROGeiHFAP8WJdI2RoxALQYgdllERc3N5N2DM=
 github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
@@ -169,7 +162,6 @@ github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 h1:Yzb9+7DPaBjB8zlTR87/ElzFsnQfuHnVUVqpZZIcV5Y=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -285,7 +277,6 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
-github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -390,7 +381,6 @@ github.com/jinzhu/gorm v1.9.12 h1:Drgk1clyWT9t9ERbzHza6Mj/8FY/CqMyVzOiHviMo6Q=
 github.com/jinzhu/gorm v1.9.12/go.mod h1:vhTjlKSJUTWNtcbQtrMBFCxy7eXTzeCAzfL5fBZT/Qs=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
-github.com/jinzhu/now v1.0.1 h1:HjfetcXq097iXP0uoPCdnM4Efp5/9MsM0/M+XOTeR3M=
 github.com/jinzhu/now v1.0.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
@@ -444,7 +434,6 @@ github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
-github.com/lib/pq v1.3.0 h1:/qkRGz8zljWiDcFvgpwUpwIAPu3r07TDvs3Rws+o/pU=
 github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
@@ -469,7 +458,6 @@ github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/mattn/go-shellwords v1.0.10/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
-github.com/mattn/go-sqlite3 v2.0.1+incompatible h1:xQ15muvnzGBHpIpdrNi1DA5x0+TcBZzsIDwmw9uTHzw=
 github.com/mattn/go-sqlite3 v2.0.1+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -761,7 +749,6 @@ golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
-golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
@@ -888,7 +875,6 @@ golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200103221440-774c71fcf114 h1:DnSr2mCsxyCE6ZgIkmcWUQY2R5cH/6wL7eIxEmQOMSE=
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/helm/portieris/templates/webhooks.yaml
+++ b/helm/portieris/templates/webhooks.yaml
@@ -23,6 +23,7 @@ webhooks:
       caBundle: {{ .Files.Get "certs/ca.crt" | b64enc }}
       {{ end }}
     rules: []
+    sideEffects: None
     admissionReviewVersions: ["v1"]
 ---
 # webhook replaces the inoperative one, after the service is installed

--- a/pkg/controller/fakecontroller/controller.go
+++ b/pkg/controller/fakecontroller/controller.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Portieris Authors.
+// Copyright 2018,2021 Portieris Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,13 +14,13 @@
 
 package fakecontroller
 
-import admissionv1beta1 "k8s.io/api/admission/v1beta1"
+import admissionv1 "k8s.io/api/admission/v1"
 
 // Controller is a fake controller for stubbing
 type Controller struct {
 }
 
 // Admit is a fake admit function for stubbing
-func (c *Controller) Admit(admissionRequest *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
-	return &admissionv1beta1.AdmissionResponse{Allowed: true}
+func (c *Controller) Admit(admissionRequest *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
+	return &admissionv1.AdmissionResponse{Allowed: true}
 }

--- a/pkg/controller/interface.go
+++ b/pkg/controller/interface.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Portieris Authors.
+// Copyright 2018,2021 Portieris Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,9 +14,9 @@
 
 package controller
 
-import admissionv1beta1 "k8s.io/api/admission/v1beta1"
+import admissionv1 "k8s.io/api/admission/v1"
 
 // Interface are the methods required to implement a controller for the webhook package
 type Interface interface {
-	Admit(*admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse
+	Admit(*admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse
 }

--- a/pkg/controller/multi/controller.go
+++ b/pkg/controller/multi/controller.go
@@ -28,7 +28,7 @@ import (
 	"github.com/IBM/portieris/pkg/webhook"
 	"github.com/IBM/portieris/types"
 	"github.com/golang/glog"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -60,7 +60,7 @@ func NewController(kubeWrapper kubernetes.WrapperInterface, policyClient policy.
 }
 
 // Admit is the admissionRequest handler
-func (c *Controller) Admit(admissionRequest *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (c *Controller) Admit(admissionRequest *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	glog.Infof("Processing admission request for %s on %s", admissionRequest.Operation, admissionRequest.Name)
 
 	podSpecLocation, ps, err := c.kubeClientsetWrapper.GetPodSpec(admissionRequest)
@@ -68,7 +68,7 @@ func (c *Controller) Admit(admissionRequest *admissionv1beta1.AdmissionRequest) 
 	case nil:
 		break
 	case kubernetes.ErrObjectHasParents, kubernetes.ErrObjectHasZeroReplicas:
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: true,
 		}
 	default:
@@ -80,7 +80,7 @@ func (c *Controller) Admit(admissionRequest *admissionv1beta1.AdmissionRequest) 
 	return c.admitPod(admissionRequest.Namespace, podSpecLocation, *ps)
 }
 
-func (c *Controller) admitPod(namespace, specPath string, pod corev1.PodSpec) *admissionv1beta1.AdmissionResponse {
+func (c *Controller) admitPod(namespace, specPath string, pod corev1.PodSpec) *admissionv1.AdmissionResponse {
 	a := &webhook.AdmissionResponder{}
 	patches := []types.JSONPatch{}
 	decisions := map[string][]string{}

--- a/pkg/controller/multi/controller_test.go
+++ b/pkg/controller/multi/controller_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	k8sv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -49,7 +49,7 @@ type mockKubeWrapper struct {
 	kubernetes.Interface
 }
 
-func (mkw *mockKubeWrapper) GetPodSpec(req *k8sv1beta1.AdmissionRequest) (string, *corev1.PodSpec, error) {
+func (mkw *mockKubeWrapper) GetPodSpec(req *admissionv1.AdmissionRequest) (string, *corev1.PodSpec, error) {
 	args := mkw.Called(req)
 	return args.String(0), args.Get(1).(*corev1.PodSpec), args.Error(2)
 }

--- a/pkg/controller/multi/notary_suite_test.go
+++ b/pkg/controller/multi/notary_suite_test.go
@@ -199,7 +199,7 @@ func newFakeRequest(image string) *http.Request {
 	req, _ := http.NewRequest("POST", "/", bytes.NewBufferString(fmt.Sprintf(`
 		{
 		  "kind": "AdmissionReview",
-		  "apiVersion": "admission.k8s.io/v1beta1",
+		  "apiVersion": "admission.k8s.io/v1",
 		  "request": {
 		    "uid": "ed782967-1c99-11e8-936d-08002789d446",
 		    "kind": {

--- a/pkg/controller/multi/notary_test.go
+++ b/pkg/controller/multi/notary_test.go
@@ -33,7 +33,7 @@ import (
 	notaryclient "github.com/theupdateframework/notary/client"
 	store "github.com/theupdateframework/notary/storage"
 	"github.com/theupdateframework/notary/tuf/data"
-	"k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
@@ -55,7 +55,7 @@ var _ = Describe("Main", func() {
 			registry1, registry2                                     string
 			fakeSecret, fakeSecret1, fakeSecret2, fakeSecretWrongReg *corev1.Secret
 			w                                                        *httptest.ResponseRecorder
-			resp                                                     *v1beta1.AdmissionReview
+			resp                                                     *admissionv1.AdmissionReview
 		)
 
 		fakeGetRepo := func() {
@@ -168,7 +168,7 @@ var _ = Describe("Main", func() {
 
 			BeforeEach(func() {
 				w = httptest.NewRecorder()
-				resp = &v1beta1.AdmissionReview{}
+				resp = &admissionv1.AdmissionReview{}
 			})
 
 			Context("if there is not a relevant policy to apply`", func() {
@@ -193,7 +193,7 @@ var _ = Describe("Main", func() {
 
 			BeforeEach(func() {
 				w = httptest.NewRecorder()
-				resp = &v1beta1.AdmissionReview{}
+				resp = &admissionv1.AdmissionReview{}
 			})
 
 			Context("if the `trust` policy was not specified`", func() {

--- a/pkg/kubernetes/podspec.go
+++ b/pkg/kubernetes/podspec.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-	"k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
@@ -60,7 +60,7 @@ var supportedKinds = map[string]struct{}{
 }
 
 // GetPodSpec retrieves the podspec from the admission request passed in
-func (w *Wrapper) GetPodSpec(ar *v1beta1.AdmissionRequest) (string, *corev1.PodSpec, error) {
+func (w *Wrapper) GetPodSpec(ar *admissionv1.AdmissionRequest) (string, *corev1.PodSpec, error) {
 	ps := corev1.PodSpec{}
 	var templateString string
 

--- a/pkg/kubernetes/podspec_test.go
+++ b/pkg/kubernetes/podspec_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
@@ -651,7 +651,7 @@ func TestWrapper_GetPodSpec(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			ar := &v1beta1.AdmissionRequest{
+			ar := &admissionv1.AdmissionRequest{
 				Resource:  tt.ar.Resource,
 				Namespace: tt.ar.Namespace,
 				Object: runtime.RawExtension{

--- a/pkg/kubernetes/wrapper.go
+++ b/pkg/kubernetes/wrapper.go
@@ -1,4 +1,4 @@
-// Copyright 2018, 2020 Portieris Authors.
+// Copyright 2018, 2021 Portieris Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 package kubernetes
 
 import (
-	"k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -29,7 +29,7 @@ var _ WrapperInterface = &Wrapper{}
 // WrapperInterface is the interface for a wrapper around kubeclientset that includes some helper functions for applying behaviour to kube resources
 type WrapperInterface interface {
 	kubernetes.Interface
-	GetPodSpec(*v1beta1.AdmissionRequest) (string, *corev1.PodSpec, error)
+	GetPodSpec(*admissionv1.AdmissionRequest) (string, *corev1.PodSpec, error)
 	GetSecretToken(namespace, secretName, registry string) (string, string, error)
 	GetSecretKey(namespace, secretName string) ([]byte, error)
 	GetBasicCredentials(namespace, secretName string) (string, string, error)

--- a/pkg/webhook/responder.go
+++ b/pkg/webhook/responder.go
@@ -1,4 +1,4 @@
-// Copyright 2018,2020 Portieris Authors.
+// Copyright 2018, 2021 Portieris Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	"k8s.io/api/admission/v1beta1"
+	v1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -33,20 +33,20 @@ type AdmissionResponder struct {
 }
 
 // Flush creates the admission response to return
-func (a *AdmissionResponder) Flush() *v1beta1.AdmissionResponse {
+func (a *AdmissionResponder) Flush() *v1.AdmissionResponse {
 	if a.allowed && !a.HasErrors() {
-		res := &v1beta1.AdmissionResponse{
+		res := &v1.AdmissionResponse{
 			Allowed: true,
 		}
 
 		if a.patches != nil {
 			res.Patch = a.patches
-			pt := v1beta1.PatchTypeJSONPatch
+			pt := v1.PatchTypeJSONPatch
 			res.PatchType = &pt
 		}
 		return res
 	}
-	return &v1beta1.AdmissionResponse{
+	return &v1.AdmissionResponse{
 		Allowed: false,
 		Result: &metav1.Status{
 			Message: fmt.Sprintf("\n%s", strings.Join(a.errors, "\n")),
@@ -75,7 +75,7 @@ func (a *AdmissionResponder) SetPatch(patch []byte) {
 }
 
 // Write writes the output of flush to the passed responsewriter
-func (a *AdmissionResponder) Write(w http.ResponseWriter, ar v1beta1.AdmissionReview) {
+func (a *AdmissionResponder) Write(w http.ResponseWriter, ar v1.AdmissionReview) {
 	resp := reviewResponseToByte(a.Flush(), ar)
 	if _, err := w.Write(resp); err != nil {
 		glog.Error(err)

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -1,4 +1,4 @@
-// Copyright 2018, 2020 Portieris Authors.
+// Copyright 2018, 2021 Portieris Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import (
 	"github.com/golang/glog"
 
 	"github.com/IBM/portieris/pkg/controller"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
@@ -63,7 +63,7 @@ func (s *Server) HandleAdmissionRequest(w http.ResponseWriter, r *http.Request) 
 	defer r.Body.Close()
 	body, _ := ioutil.ReadAll(r.Body)
 
-	var admissionReview admissionv1beta1.AdmissionReview
+	var admissionReview admissionv1.AdmissionReview
 	responder := &AdmissionResponder{}
 	deserializer := codec.UniversalDeserializer()
 	if _, _, err := deserializer.Decode(body, nil, &admissionReview); err != nil {
@@ -129,8 +129,8 @@ func (s *Server) Run() {
 	server.ListenAndServeTLS("", "")
 }
 
-func reviewResponseToByte(admissionResponse *admissionv1beta1.AdmissionResponse, admissionReview admissionv1beta1.AdmissionReview) []byte {
-	response := admissionv1beta1.AdmissionReview{}
+func reviewResponseToByte(admissionResponse *admissionv1.AdmissionResponse, admissionReview admissionv1.AdmissionReview) []byte {
+	response := admissionv1.AdmissionReview{}
 	if admissionResponse != nil {
 		response.Response = admissionResponse
 		if admissionReview.Request != nil {

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Portieris Authors.
+// Copyright 2018, 2021 Portieris Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	fakeController "github.com/IBM/portieris/pkg/controller/fakecontroller"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -40,13 +40,13 @@ func TestServer_HandleAdmissionRequest(t *testing.T) {
 
 	tests := []struct {
 		name            string
-		admissionReview admissionv1beta1.AdmissionReview
+		admissionReview admissionv1.AdmissionReview
 		allowed         bool
 	}{
 		{
 			name: "Calls controller admit with admissionRequest from http request",
-			admissionReview: admissionv1beta1.AdmissionReview{
-				Request: &admissionv1beta1.AdmissionRequest{UID: "requestUID"},
+			admissionReview: admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{UID: "requestUID"},
 			},
 			allowed: true,
 		},
@@ -64,7 +64,7 @@ func TestServer_HandleAdmissionRequest(t *testing.T) {
 			handler := http.HandlerFunc(server.HandleAdmissionRequest)
 			handler.ServeHTTP(rr, req)
 
-			var reviewOut admissionv1beta1.AdmissionReview
+			var reviewOut admissionv1.AdmissionReview
 			bytesOut, _ := ioutil.ReadAll(rr.Body)
 			json.Unmarshal(bytesOut, &reviewOut)
 			assert.Equal(t, tt.allowed, reviewOut.Response.Allowed)
@@ -75,39 +75,39 @@ func TestServer_HandleAdmissionRequest(t *testing.T) {
 func Test_reviewResponseToByte(t *testing.T) {
 	tests := []struct {
 		name                string
-		admissionResponse   *admissionv1beta1.AdmissionResponse
-		admissionReview     admissionv1beta1.AdmissionReview
-		wantAdmissionReview admissionv1beta1.AdmissionReview
+		admissionResponse   *admissionv1.AdmissionResponse
+		admissionReview     admissionv1.AdmissionReview
+		wantAdmissionReview admissionv1.AdmissionReview
 	}{
 		{
 			name:              "Review response matches inputted review with matching request/response UID",
-			admissionResponse: &admissionv1beta1.AdmissionResponse{UID: "responseUID", Allowed: true},
-			admissionReview: admissionv1beta1.AdmissionReview{
-				Request: &admissionv1beta1.AdmissionRequest{UID: "requestUID"},
+			admissionResponse: &admissionv1.AdmissionResponse{UID: "responseUID", Allowed: true},
+			admissionReview: admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{UID: "requestUID"},
 			},
-			wantAdmissionReview: admissionv1beta1.AdmissionReview{
-				Response: &admissionv1beta1.AdmissionResponse{UID: "requestUID", Allowed: true},
+			wantAdmissionReview: admissionv1.AdmissionReview{
+				Response: &admissionv1.AdmissionResponse{UID: "requestUID", Allowed: true},
 			},
 		},
 		{
 			name:              "Review response object and oldobject are reset",
-			admissionResponse: &admissionv1beta1.AdmissionResponse{},
-			admissionReview: admissionv1beta1.AdmissionReview{
-				Request: &admissionv1beta1.AdmissionRequest{
+			admissionResponse: &admissionv1.AdmissionResponse{},
+			admissionReview: admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
 					UID:       "requestUID",
 					Object:    runtime.RawExtension{Raw: []byte("SomeBytes")},
 					OldObject: runtime.RawExtension{Raw: []byte("SomeBytes")},
 				},
 			},
-			wantAdmissionReview: admissionv1beta1.AdmissionReview{
-				Response: &admissionv1beta1.AdmissionResponse{UID: "requestUID"},
+			wantAdmissionReview: admissionv1.AdmissionReview{
+				Response: &admissionv1.AdmissionResponse{UID: "requestUID"},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bytes := reviewResponseToByte(tt.admissionResponse, tt.admissionReview)
-			var review admissionv1beta1.AdmissionReview
+			var review admissionv1.AdmissionReview
 			json.Unmarshal(bytes, &review)
 			assert.Equal(t, tt.wantAdmissionReview, review)
 		})


### PR DESCRIPTION
Moving to the v1 webhook not so simple, obviously requires that the response is of the v1 type.

Signed-off-by: Stuart Hayton <stuart.hayton@uk.ibm.com>

issue: https://github.com/IBM/portieris/issues/215