### PR TITLE
add ability to set podAnnotations on deployment resource

### DIFF
--- a/helm/portieris/templates/deployment.yaml
+++ b/helm/portieris/templates/deployment.yaml
@@ -17,8 +17,10 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/scrape: 'true'
-        prometheus.io/port: '8080'
+      {{- $metric_annotations := dict "prometheus.io/scrape" "true" "prometheus.io/port" "8080" }}
+      {{- with mergeOverwrite $metric_annotations .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: portieris
         release: {{ .Release.Name }}

--- a/helm/portieris/values.yaml
+++ b/helm/portieris/values.yaml
@@ -4,6 +4,10 @@
 
 replicaCount: 3
 
+# Annotations to add to the Portieris deployment's pod template. Optional.
+podAnnotations: {}
+  # sidecar.istio.io/inject: "false"
+
 image:
   host: icr.io/portieris
   pullSecret:


### PR DESCRIPTION
# Description

Resolves #323 

The following change is intended to allow an administrator more flexibility when configuring a Portieris deployment. It is common for security tools to demand certain `podAnnotations` are set in order to reach a specified level of compliance or a service mesh to use `podAnnotations` to change its configuration. 

The change will allow users to overwrite the metric annotations if the user provides matching keys. Introducing `$metric_annotations` and `mergeOverwrite` produces a more predictable outcome, and ensures the user cannot duplicate annotations. If no pod annotations are given the `prometheus.io/port: "8080"` and `prometheus.io/scrape: "true"` will be the default

# Changes
- Add ability to optionally set `podAnnotations` on the deployment resource

# Testing

### Empty Map

`values.yaml`
```yaml
podAnnotations: {}
```

Result

`helm install empty helm/portieris/ --dry-run --values values.yaml`
```yaml
# Source: portieris/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: added-annotations-portieris
  namespace: default
  labels:
    app: portieris
    chart: portieris-v0.10.2
    release: added-annotations
    heritage: Helm
spec:
  replicas: 3
  selector:
    matchLabels:
      app: portieris
      release: added-annotations
  template:
    metadata:
      annotations:
        prometheus.io/port: "8080"
        prometheus.io/scrape: "true"
```

### Non-Empty Map

`values.yaml`
```yaml
podAnnotations:
  sidecar.istio.io/inject: "false"
  prometheus.io/scrape: "false"
  container.apparmor.security.beta.kubernetes.io/portieris: "runtime/default"
  prometheus.io/port: "90000"
```

Result

`helm install added-annotations helm/portieris/ --dry-run --values values.yaml`
```yaml
# Source: portieris/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: added-annotations-portieris
  namespace: default
  labels:
    app: portieris
    chart: portieris-v0.10.2
    release: added-annotations
    heritage: Helm
spec:
  replicas: 3
  selector:
    matchLabels:
      app: portieris
      release: added-annotations
  template:
    metadata:
      annotations:
        container.apparmor.security.beta.kubernetes.io/portieris: runtime/default
        prometheus.io/port: "90000"
        prometheus.io/scrape: "false"
        sidecar.istio.io/inject: "false"
```