### PR TITLE
Remove invalid `inline` struct tag

### DIFF
--- a/pkg/apis/portieris.cloud.ibm.com/v1/types.go
+++ b/pkg/apis/portieris.cloud.ibm.com/v1/types.go
@@ -39,7 +39,7 @@ func boolPointer(boolean bool) *bool {
 
 // ImagePolicy is a specification for a ImagePolicy resource
 type ImagePolicy struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec ImagePolicySpec `json:"spec"`
@@ -49,7 +49,7 @@ type ImagePolicy struct {
 
 // ImagePolicyList is a list of ImagePolicy resources
 type ImagePolicyList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta
 	metav1.ListMeta `json:"metadata"`
 
 	Items []ImagePolicy `json:"items"`
@@ -62,7 +62,7 @@ type ImagePolicyList struct {
 
 // ClusterImagePolicy is a specification for a ClusterImagePolicy resource
 type ClusterImagePolicy struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec ImagePolicySpec `json:"spec"`
@@ -72,7 +72,7 @@ type ClusterImagePolicy struct {
 
 // ClusterImagePolicyList is a list of ClusterImagePolicy resources
 type ClusterImagePolicyList struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta
 	metav1.ListMeta `json:"metadata"`
 
 	Items []ClusterImagePolicy `json:"items"`


### PR DESCRIPTION
Apparently there is no "inline" struct tag that encoding/json recognizes. The Kubernetes repo uses it all over the place, but it does not actually do anything.

There's an open issue to add the feature in, however it's not been closed yet.
See https://github.com/golang/go/issues/6213

Issue Link: https://github.com/IBM/portieris/issues/276

Signed off by: Adrian Osadcenco adrian.osadcenco@ibm.com

Also see source code for the `encoding/json` library, there is no mention of an `inline` struct tag.
[https://github.com/golang/go/blob/master/src/encoding/json/encode.go#L78-L134](url)