### PR TITLE
fix: use cert-manager v1 APIs

### DIFF
--- a/helm/portieris/templates/secret.yaml
+++ b/helm/portieris/templates/secret.yaml
@@ -1,6 +1,6 @@
 {{ if not .Values.SkipSecretCreation }}
 {{ if .Values.UseCertManager }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: portieris
@@ -8,7 +8,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: portieris-certs


### PR DESCRIPTION
Legacy API versions have been removed from cert-manager since the v1.6 release
Including v1alph2, v1alph3, and v1beta1

Learn more
- https://cert-manager.io/docs/release-notes/release-notes-1.6/

This has been tested in our v1.21 IKS cluster