### PR TITLE
Make CA cert definable

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,8 @@ Portieris is installed by using a Helm chart. Before you begin, ensure that you 
      tar xzvf portieris-0.9.4.tgz
      ```
      
-  3. Run:
+  3. Generate your CA certificate as well as a certificate/key pair for your webhook server, signed by the CA you created. Add these to the `values.yaml` file under `UseGeneratedCerts`. Be sure to also set `enabled` to true. For more detailed instructions, see the README under `helm/portieris`.
   
-     ```
-     sh ./portieris/gencerts
-     ```
-     
-     The `gencerts` script generates new SSL certificates and keys for Portieris. Portieris presents this certificate to the Kubernetes API server when the API server makes admission requests. If you don't generate new certificates, an attacker could imitate Portieris in your cluster.
   4. Run:
   
      ```

--- a/helm/portieris/README.md
+++ b/helm/portieris/README.md
@@ -26,11 +26,33 @@ This chart does the following tasks:
 
 ## Installing the chart
 
-### Regenerate certificates
+### Define certificates
 
-This installation uses the default certificates. To avoid using the default certificates, check out the source project at the release level and run the `./gencerts` script.
+You will need the following:
+* A CA certificate
+* A server certificate, signed by the CA
+* A private key for the server certificate
 
-**Important** If you don't run the `./gencerts` script, you will deploy with certificates that are publicly accessible on GitHub.
+Note: If you want, you can use the `gencerts` script to generate these automatically for you.
+
+Next, you will need to add the contents of these three files to your values.json. Under `UseGeneratedCerts` you will add them to `tlsCert`, `tlsKey`, and `caCert` respectively. Also be sure to set `enabled` to true. The resulting section of the values file should look something like this:
+```
+UseGeneratedCerts:
+  enabled: true
+  tlsCert: |
+    -----BEGIN CERTIFICATE-----
+    ...certificate data...
+    -----END CERTIFICATE-----
+  tlsKey: |
+    -----BEGIN CERTIFICATE-----
+    ...key data...
+    -----END CERTIFICATE-----
+  caCert: |
+    -----BEGIN CERTIFICATE-----
+    ...certificate data...
+    -----END CERTIFICATE-----
+```
+Include every line of the certificate/key files, making sure you use proper indentation before each line so as to produce a valid YAML.
 
 ### IBM Cloud Kubernetes Service
 

--- a/helm/portieris/templates/webhooks.yaml
+++ b/helm/portieris/templates/webhooks.yaml
@@ -20,7 +20,11 @@ webhooks:
         namespace: {{ .Release.Namespace }}
         path: "/admit"
       {{ if not .Values.UseCertManager }}
+      {{ if .Values.UseGeneratedCerts.enabled }}
+      caBundle: {{ required "A valid .Values.UseGeneratedCerts.caCert entry required!" .Values.UseGeneratedCerts.caCert | b64enc | quote }}
+      {{ else }}
       caBundle: {{ .Files.Get "certs/ca.crt" | b64enc }}
+      {{ end }}
       {{ end }}
     rules: []
     sideEffects: None
@@ -49,7 +53,11 @@ webhooks:
         namespace: {{ .Release.Namespace }}
         path: "/admit"
       {{ if not .Values.UseCertManager }}
+      {{ if .Values.UseGeneratedCerts.enabled }}
+      caBundle: {{ required "A valid .Values.UseGeneratedCerts.caCert entry required!" .Values.UseGeneratedCerts.caCert | b64enc | quote }}
+      {{ else }}
       caBundle: {{ .Files.Get "certs/ca.crt" | b64enc }}
+      {{ end }}
       {{ end }}
     rules:
       - operations: [ "CREATE", "UPDATE" ]

--- a/helm/portieris/values.yaml
+++ b/helm/portieris/values.yaml
@@ -44,6 +44,7 @@ UseGeneratedCerts:
   enabled: false
   tlsCert: |-
   tlsKey: |-
+  caCert: |-
 
 # Resoures defined to assist scheduling
 # request is typical x10, limit is typical x100


### PR DESCRIPTION
The values file allows you to define `tlsCert` and `tlsKey` when `UseGeneratedCerts` is set to true. But there is no way to define the ca cert used by the webhooks when you aren't using cert-manager, it only allows you to define it from the generated ca.crt file, which seems to defeat the purpose. This PR allows this CA cert to be defined from values.