### PR TITLE
Forbidden handing

### DIFF
--- a/helpers/image/image_test.go
+++ b/helpers/image/image_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Portieris Authors.
+// Copyright 2018, 2022 Portieris Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/verifier/trust/verifier.go
+++ b/pkg/verifier/trust/verifier.go
@@ -105,6 +105,9 @@ func (v *Verifier) VerifyByPolicy(namespace string, img *image.Reference, creden
 			if strings.Contains(err.Error(), "401") {
 				continue
 			}
+			if strings.Contains(err.Error(), "403") {
+				continue
+			}
 
 			if _, ok := err.(store.ErrServerUnavailable); ok {
 				glog.Errorf("Trust server unavailable: %v", err)


### PR DESCRIPTION
Handle "Forbidden/403" correctly on trust where multiple secrets are available. 
Tested in e2e tests.