### PR TITLE
move tests to current CronJob version

### DIFF
--- a/test/e2e/utils/cronjob.go
+++ b/test/e2e/utils/cronjob.go
@@ -20,10 +20,10 @@ import (
 
 	"github.com/IBM/portieris/test/framework"
 	"github.com/stretchr/testify/assert"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 )
 
-func buildCronJob(t *testing.T, fw *framework.Framework, manifestLocation, namespace string, expectCreateFail bool) *batchv1beta1.CronJob {
+func buildCronJob(t *testing.T, fw *framework.Framework, manifestLocation, namespace string, expectCreateFail bool) *batchv1.CronJob {
 	manifest, err := fw.LoadCronJobManifest(manifestLocation)
 	if err != nil {
 		t.Fatalf("Error loading manifest: %v", err)

--- a/test/framework/cronjob.go
+++ b/test/framework/cronjob.go
@@ -20,7 +20,7 @@ import (
 
 	"time"
 
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -28,23 +28,23 @@ import (
 )
 
 // ListCronJobs lists all the Cron Jobs that are associated with the installed Helm release.
-func (f *Framework) ListCronJobs() (*batchv1beta1.CronJobList, error) {
+func (f *Framework) ListCronJobs() (*batchv1.CronJobList, error) {
 	opts := f.getHelmReleaseSelectorListOptions()
-	return f.KubeClient.BatchV1beta1().CronJobs(corev1.NamespaceAll).List(context.TODO(), opts)
+	return f.KubeClient.BatchV1().CronJobs(corev1.NamespaceAll).List(context.TODO(), opts)
 }
 
 // GetCronJob retrieves the specified Cron Job.
-func (f *Framework) GetCronJob(name, namespace string) (*batchv1beta1.CronJob, error) {
-	return f.KubeClient.BatchV1beta1().CronJobs(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+func (f *Framework) GetCronJob(name, namespace string) (*batchv1.CronJob, error) {
+	return f.KubeClient.BatchV1().CronJobs(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
 // LoadCronJobManifest takes a manifest and decodes it into a Cron Job object.
-func (f *Framework) LoadCronJobManifest(pathToManifest string) (*batchv1beta1.CronJob, error) {
+func (f *Framework) LoadCronJobManifest(pathToManifest string) (*batchv1.CronJob, error) {
 	manifest, err := openFile(pathToManifest)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to open file %q: %v", pathToManifest, err)
 	}
-	job := batchv1beta1.CronJob{}
+	job := batchv1.CronJob{}
 	if err := yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&job); err != nil {
 		return nil, fmt.Errorf("Unable to decode file %q: %v", pathToManifest, err)
 	}
@@ -52,8 +52,8 @@ func (f *Framework) LoadCronJobManifest(pathToManifest string) (*batchv1beta1.Cr
 }
 
 // CreateCronJob creates a Cron Job resource and then waits for it to show.
-func (f *Framework) CreateCronJob(namespace string, job *batchv1beta1.CronJob) error {
-	if _, err := f.KubeClient.BatchV1beta1().CronJobs(namespace).Create(context.TODO(), job, metav1.CreateOptions{}); err != nil {
+func (f *Framework) CreateCronJob(namespace string, job *batchv1.CronJob) error {
+	if _, err := f.KubeClient.BatchV1().CronJobs(namespace).Create(context.TODO(), job, metav1.CreateOptions{}); err != nil {
 		return err
 	}
 	return f.WaitForCronJob(job.Name, namespace, 2*time.Minute)

--- a/test/framework/namespace.go
+++ b/test/framework/namespace.go
@@ -1,4 +1,4 @@
-// Copyright 2018, 2021 Portieris Authors.
+// Copyright 2018, 2022 Portieris Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -80,6 +80,9 @@ func (f *Framework) CreateNamespaceWithIPS(name string) (*corev1.Namespace, erro
 	var imagePullSecret *v1.Secret
 	for _, secretName := range IBMCloudSecretNames {
 		imagePullSecret, err = f.KubeClient.CoreV1().Secrets("default").Get(context.TODO(), secretName, metav1.GetOptions{})
+		if err == nil {
+			break
+		}
 	}
 	if imagePullSecret == nil {
 		return nil, fmt.Errorf("error getting imagePullSecret: %v", err)


### PR DESCRIPTION
switch tests to batch/v1 from batchv1beta1 (required by 1.25) 