### PR TITLE
feat: add deployemntAnnotations to the helm chart 

### DIFF
--- a/helm/portieris/templates/deployment.yaml
+++ b/helm/portieris/templates/deployment.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: {{ template "portieris.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.deployemntAnnotations }}
+  annotations:
+      {{- toYaml . | nindent 8 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/helm/portieris/templates/deployment.yaml
+++ b/helm/portieris/templates/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
   {{- with .Values.deployemntAnnotations }}
   annotations:
-      {{- toYaml . | nindent 8 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}

--- a/helm/portieris/values.yaml
+++ b/helm/portieris/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 3
 
 # Annotations to add to the Portieris deployment. Optional.
 deployemntAnnotations: {}
-
+  # secret.reloader.stakater.com/reload: "portieris-certs"
 # Annotations to add to the Portieris deployment's pod template. Optional.
 podAnnotations: {}
   # sidecar.istio.io/inject: "false"

--- a/helm/portieris/values.yaml
+++ b/helm/portieris/values.yaml
@@ -4,6 +4,9 @@
 
 replicaCount: 3
 
+# Annotations to add to the Portieris deployment. Optional.
+deployemntAnnotations: {}
+
 # Annotations to add to the Portieris deployment's pod template. Optional.
 podAnnotations: {}
   # sidecar.istio.io/inject: "false"


### PR DESCRIPTION
Hi,

Helm upgrade doesn’t restart the deployment, if the deployment manifest doesn’t get changed. There is a solution for that https://v3.helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments.

For that case additional annotations should be added to the deployment itself. 