### PR TITLE
Allow using external cert manager issuer

### DIFF
--- a/helm/portieris/templates/secret.yaml
+++ b/helm/portieris/templates/secret.yaml
@@ -1,13 +1,15 @@
 {{ if not .Values.SkipSecretCreation }}
 {{ if .Values.UseCertManager }}
+{{ if not .Values.certManagerIssuer.skipCreation }}
 apiVersion: cert-manager.io/v1
-kind: Issuer
+kind: {{ .Values.certManagerIssuer.kind }}
 metadata:
-  name: portieris
+  name: {{ .Values.certManagerIssuer.name }}
   namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
 ---
+{{ end }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -18,7 +20,8 @@ spec:
     - portieris.{{ .Release.Namespace }}.svc
   secretName: portieris-certs
   issuerRef:
-    name: portieris
+    kind: {{ .Values.certManagerIssuer.kind }}
+    name: {{ .Values.certManagerIssuer.name }}
 {{ else }}
 apiVersion: v1
 kind: Secret

--- a/helm/portieris/values.yaml
+++ b/helm/portieris/values.yaml
@@ -36,6 +36,10 @@ SkipSecretCreation: false
 
 # If using cert-manager to handle secrets
 UseCertManager: false
+certManagerIssuer:
+  skipCreation: false
+  kind: Issuer
+  name: portieris
 
 ## Use generated certs from values file.
 ## Ref: https://github.com/IBM/portieris/blob/main/helm/portieris/gencerts


### PR DESCRIPTION
Currently, always a new issuer is created for portieris. This PR exposes overrides so that one can configure an already existing issuer to be used.

This is especially important for rotation use-cases. Currently, since self-signed issuer is used on each rotation the certificate is issued by a different issuer. This means that the old certificate is automatically invalid since the issuer is different. Portieris deployment needs to be restarted in order to pick up the new cert.

If we manage to use an existing cert-manager issuer, one can configure a stable one that will be used for portieris certificates. This way, when a certificate is rotated, the issuer will be the same and the cert will be valid for a few days more until it actually expires - enough time for redeployment to happen and portieris to pick up the new cert.