### PR TITLE
Change semverCompare in PDB

### DIFF
--- a/helm/portieris/templates/pdb.yaml
+++ b/helm/portieris/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget }}
-{{- if semverCompare ">=1.21.0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: policy/v1
 {{- else -}}
 apiVersion: policy/v1beta1


### PR DESCRIPTION
Currently, we are experiencing some issues with the `semverCompare` logic inside the PDB of the Helm chart as it cannot handle the Kubernetes GitVersion for clusters on GKE. 

The output of running `kubectl version`:
<img width="1057" alt="image" src="https://github.com/IBM/portieris/assets/62294535/dcd87307-e4a6-4c07-bd7b-c9612fc80c0b">

`.Capabilities.KubeVersion.GitVersion` looks at the GitVersion of the Kubernetes cluster; in our case that is a GKE cluster which has the GitVersion of `GitVersion:"v1.24.16-gke.500"` (retrieved by running `kubectl version`). The issue stems from the `-gke.500` which according to the [Helm docs](https://helm.sh/docs/chart_template_guide/function_list/#working-with-prerelease-versions) is considered as a pre-release.

The solution provided seems to work both with GitVersion without a pre-release, such as `1.20.0` or `1.24.0`, and GitVersions with a pre-release, such as  `1.20.0-alpha` and `v1.21.0-beta.500-orca`.

It should be considered that adding `-0` to the semverCompare string will be treated as a "pre-release" and that is not the case for GKE with its `-gke.500`.

Another solution that removes this "pre-release" concern could be `{{- if and (eq 1 (int .Capabilities.KubeVersion.Major)) (ge (int .Capabilities.KubeVersion.Minor) 21)  -}}` - not as clean, but more understandable and error-proof.
