### PR TITLE
feat: add namespace selector for skipping admission

### DIFF
--- a/helm/portieris/templates/webhooks.yaml
+++ b/helm/portieris/templates/webhooks.yaml
@@ -67,14 +67,20 @@ webhooks:
     failurePolicy: {{ .Values.webHooks.failurePolicy }}
     sideEffects: None
     admissionReviewVersions: ["v1"]
-    {{ if .Values.AllowAdmissionSkip }}
+    {{- if or (.Values.AllowAdmissionSkip) (.Values.NamespaceSelectorAdmissionSkip) }}
     namespaceSelector:
       matchExpressions:
+      {{- if .Values.AllowAdmissionSkip}}
       - key: securityenforcement.admission.cloud.ibm.com/namespace
         operator: NotIn
         values:
         - skip
-    {{ end }}
+      {{- end }}
+      
+      {{- with .Values.NamespaceSelectorAdmissionSkip }}
+{{ toYaml . | indent 6 }}
+      {{- end }}
+    {{- end }}
     {{ if .Values.ObjectSelectorAdmissionSkip }}
     objectSelector:
 {{ toYaml .Values.ObjectSelectorAdmissionSkip | indent 6 }}

--- a/helm/portieris/values.yaml
+++ b/helm/portieris/values.yaml
@@ -109,6 +109,12 @@ ObjectSelectorAdmissionSkip:
     #     values:
     #     - xxxx
 
+NamespaceSelectorAdmissionSkip:
+  #- key: kubernetes.io/metadata.name
+  #  operator: NotIn
+  #  values:
+  #    - kube-system
+
 clusterPolicy:
   allowedRepositories:
     # This permissive policy allows all images in namespaces which do not have an ImagePolicy.


### PR DESCRIPTION
Hi there,

part of the admission control [best practises is to skip kube-system namespace](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#avoiding-operating-on-the-kube-system-namespace). This PR would add an option for a user to create a matchExpression which suits their case.

Hope that suits well,
Johnny