### PR TITLE
Prep v0.13.20

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.*|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-08-19T17:46:31Z",
+  "generated_at": "2024-10-14T13:08:32Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v-next
 
+## v0.13.20
+Released: 2024-10-11
+
+* Remediates CVE-2024-9355 in golang
+
 ## v0.13.19
 Released: 2024-09-30
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GOFILES=$(shell find . -type f -name '*.go' -not -path "./code-generator/*" -not -path "./pkg/apis/*")
 GOPACKAGES=$(shell go list ./... | grep -v test/ | grep -v pkg/apis/)
 
-VERSION=v0.13.19
+VERSION=v0.13.20
 TAG=$(VERSION)
 GOTAGS='containers_image_openpgp'
 

--- a/helm/portieris/Chart.yaml
+++ b/helm/portieris/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: portieris
-version: v0.13.19
+version: v0.13.20
 description: Admission Controller webhook for enforcing image trust in your cluster
 maintainers:
   - name: Stuart Hayton

--- a/helm/portieris/values.yaml
+++ b/helm/portieris/values.yaml
@@ -15,7 +15,7 @@ image:
   host: icr.io/portieris
   pullSecret:
   image: portieris
-  tag: v0.13.19
+  tag: v0.13.20
   pullPolicy: Always
 
 service:

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -2,7 +2,7 @@
 export PORTIERIS_PULL_APIKEY=
 export PORTIERIS_TESTIMAGE_APIKEY=
 # charts to test
-export VERSION=v0.13.19
+export VERSION=
 # image tag to test e.g. prep-v0.13.19
 export TAG=
 


### PR DESCRIPTION
Remediates CVE-2024-9355 in golang

A rebuild should fix this as we are using `registry.access.redhat.com/ubi8/go-toolset:1.21.13` and that says it has `golang-1.21.13-3.module+el8.10.0+22345+acdd8d0e.x86_64` which is what the vuln issue asked for:
`Corrective action: Upgrade golang to >= 0:1.21.13-3.module+el8.10.0+22345+acdd8d0e`

Reference: https://catalog.redhat.com/software/containers/ubi8/go-toolset/5ce8713aac3db925c03774d1?container-tabs=packages

Locally tested as per [the runbook](https://pages.github.ibm.com/alchemy-registry/operational-docs/runbooks/cr/release_portieris/#action-to-take---test) and all was successfull.