### PR TITLE
Prep release v0.13.24

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.*|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-02-13T15:51:39Z",
+  "generated_at": "2025-02-19T17:54:42Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1170,7 +1170,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.61.dss",
+  "version": "0.13.1+ibm.62.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## v-next
 
 ## v0.13.24
-Released: 2025-02-13
+Released: 2025-02-19
 
 * Update to github.com/golang/glog:v1.24.0 for CVE-2024-45339
 


### PR DESCRIPTION
@tim-gp already did most of the legwork for creating this release in #479. This just needs updating the release date.