### PR TITLE
Prep release v0.13.25

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,1 +1,2 @@
 CVE-2023-27561 until=2023-04-11 # https://github.com/IBM/portieris/issues/433
+CVE-2025-22869 until=2025-04-07 # https://github.ibm.com/alchemy-registry/va-registry-psirt/issues/418

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ---
 
 copyright:
-  years: 2020-2024
-lastupdated: "2024-05-14"
+  years: 2020-2025
+lastupdated: "2025-03-07"
 
 ---
 
@@ -12,6 +12,11 @@ Notable changes recorded here.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v-next
+
+## v0.13.25
+Released: 2025-03-07
+
+* Update to github.com/go-jose/go-jose:4.0.5 for CVE-2025-27144
 
 ## v0.13.24
 Released: 2025-02-19

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GOFILES=$(shell find . -type f -name '*.go' -not -path "./code-generator/*" -not -path "./pkg/apis/*")
 GOPACKAGES=$(shell go list ./... | grep -v test/ | grep -v pkg/apis/)
 
-VERSION=v0.13.24
+VERSION=v0.13.25
 TAG=$(VERSION)
 GOTAGS='containers_image_openpgp'
 

--- a/helm/portieris/Chart.yaml
+++ b/helm/portieris/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: portieris
-version: v0.13.24
+version: v0.13.25
 description: Admission Controller webhook for enforcing image trust in your cluster
 maintainers:
   - name: Stuart Hayton

--- a/helm/portieris/values.yaml
+++ b/helm/portieris/values.yaml
@@ -15,7 +15,7 @@ image:
   host: icr.io/portieris
   pullSecret:
   image: portieris
-  tag: v0.13.24
+  tag: v0.13.25
   pullPolicy: Always
 
 service:


### PR DESCRIPTION
v0.13.25 to release a vuln fix to go-jose (plus associated dependency updates)

A nancy-ignore is added for a separate vuln that cannot be fixed until refactoring the dockerbuild to use a higher golang version than RedHat currently provide