### PR TITLE
Make webhook timeouts configurable

### DIFF
--- a/helm/portieris/templates/webhooks.yaml
+++ b/helm/portieris/templates/webhooks.yaml
@@ -29,6 +29,9 @@ webhooks:
     rules: []
     sideEffects: None
     admissionReviewVersions: ["v1"]
+    {{ if .Values.webHooks.timeoutSeconds }}
+    timeoutSeconds: {{ .Values.webHooks.timeoutSeconds }}
+    {{- end }}
 ---
 # webhook replaces the inoperative one, after the service is installed
 apiVersion: admissionregistration.k8s.io/v1
@@ -85,3 +88,6 @@ webhooks:
     objectSelector:
 {{ toYaml .Values.ObjectSelectorAdmissionSkip | indent 6 }}
     {{ end }}
+    {{ if .Values.webHooks.timeoutSeconds }}
+    timeoutSeconds: {{ .Values.webHooks.timeoutSeconds }}
+    {{- end }}


### PR DESCRIPTION
I'm proposing a change to resolve the following feature request: https://github.com/IBM/portieris/issues/496.