### PR TITLE
Prep release v0.13.38

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.*|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-01-28T15:11:19Z",
+  "generated_at": "2026-05-06T16:09:24Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ---
 copyright:
   years: 2020-2026
-lastupdated: "2026-04-08"
+lastupdated: "2026-05-05"
 ---
 
 # Change Log
@@ -10,6 +10,15 @@ Notable changes recorded here.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v-next
+
+## v0.13.38
+
+Release: 2026-05-05
+
+- Remove deprecated `distribution/distribution/registry/client/transport` dependency (removed in distribution v3)
+- Implement replacement HTTP transport with full functionality and proper Apache 2.0 attribution
+- Add `docker/docker => moby/moby` replace directive for Docker v29+ compatibility
+- Update copyright years to 2026
 
 ## v0.13.37
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 Release: 2026-05-05
 
 - Remove deprecated `distribution/distribution/registry/client/transport` dependency (removed in distribution v3)
-- Implement replacement HTTP transport with full functionality and proper Apache 2.0 attribution
-- Add `docker/docker => moby/moby` replace directive for Docker v29+ compatibility
-- Update copyright years to 2026
+- Implement replacement simplified HTTP transport with attribution
 
 ## v0.13.37
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GOFILES=$(shell find . -type f -name '*.go' -not -path "./code-generator/*" -not -path "./pkg/apis/*")
 GOPACKAGES=$(shell go list ./... | grep -v test/ | grep -v pkg/apis/)
 
-VERSION=v0.13.37
+VERSION=v0.13.38
 TAG=$(VERSION)
 GOTAGS='containers_image_openpgp'
 GOPROXY?=direct

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ replace (
 require (
 	github.com/IBM/go-sdk-core/v5 v5.21.2
 	github.com/containers/image/v5 v5.36.2
-	github.com/distribution/distribution v2.8.3+incompatible
 	github.com/distribution/reference v0.6.0
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang/glog v1.2.5

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,6 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denisenkom/go-mssqldb v0.0.0-20191128021309-1d7a30a10f73/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
-github.com/distribution/distribution v2.8.3+incompatible h1:RlpEXBLq/WPXYvBYMDAmBX/SnhD67qwtvW/DzKc8pAo=
-github.com/distribution/distribution v2.8.3+incompatible/go.mod h1:EgLm2NgWtdKgzF9NpMzUKgzmR7AMmb0VQi2B+ZzDRjc=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/cli v29.0.3+incompatible h1:8J+PZIcF2xLd6h5sHPsp5pvvJA+Sr2wGQxHkRl53a1E=

--- a/helm/portieris/Chart.yaml
+++ b/helm/portieris/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: portieris
-version: v0.13.37
+version: v0.13.38
 description: Admission Controller webhook for enforcing image trust in your cluster
 maintainers:
   - name: Stuart Hayton

--- a/helm/portieris/values.yaml
+++ b/helm/portieris/values.yaml
@@ -15,7 +15,7 @@ image:
   host: icr.io/portieris
   pullSecret:
   image: portieris
-  tag: v0.13.37
+  tag: v0.13.38
   pullPolicy: Always
 
 service:

--- a/pkg/notary/notary.go
+++ b/pkg/notary/notary.go
@@ -1,4 +1,4 @@
-// Copyright 2018, 2025 Portieris Authors.
+// Copyright 2018, 2026 Portieris Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import (
 	httphelper "github.com/IBM/portieris/helpers/http"
 	"github.com/IBM/portieris/helpers/image"
 	"github.com/IBM/portieris/internal/info"
-	"github.com/distribution/distribution/registry/client/transport"
 	notaryclient "github.com/theupdateframework/notary/client"
 	"github.com/theupdateframework/notary/trustpinning"
 	"github.com/theupdateframework/notary/tuf/data"
@@ -148,22 +147,18 @@ func (c Client) makeHubTransport(notaryToken string) http.RoundTripper {
 		DisableKeepAlives: true,
 	}
 
-	modifiers := []transport.RequestModifier{
-		transport.NewHeaderRequestModifier(http.Header{
-			"User-Agent": []string{"portieris/" + info.Version},
-		}),
+	headers := http.Header{
+		"User-Agent": []string{"portieris/" + info.Version},
 	}
 
 	if notaryToken != "" {
-		modifiers = []transport.RequestModifier{
-			transport.NewHeaderRequestModifier(http.Header{
-				"User-Agent":    []string{"portieris/" + info.Version},
-				"Authorization": []string{fmt.Sprintf("Bearer %s", notaryToken)},
-			}),
-		}
+		headers.Set("Authorization", fmt.Sprintf("Bearer %s", notaryToken))
 	}
 
-	return transport.NewTransport(base, modifiers...)
+	return &headerTransport{
+		base:    base,
+		headers: headers,
+	}
 }
 
 func createTrustDir(trustDir string) error {

--- a/pkg/notary/transport.go
+++ b/pkg/notary/transport.go
@@ -65,5 +65,3 @@ func (t *headerTransport) cloneRequest(r *http.Request) *http.Request {
 	}
 	return r2
 }
-
-// Made with Bob

--- a/pkg/notary/transport.go
+++ b/pkg/notary/transport.go
@@ -1,0 +1,69 @@
+// Copyright 2018, 2026 Portieris Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains HTTP transport functionality derived from
+// github.com/distribution/distribution/registry/client/transport
+// which was removed in distribution v3.
+//
+// Original code: Copyright Docker, Inc.
+// Original license: Apache License 2.0
+// Source: https://github.com/distribution/distribution/blob/v2.8.3/registry/client/transport/transport.go
+//
+// Modifications made by Portieris Authors:
+// - Adapted to work as a standalone implementation without distribution package dependency
+// - Simplified to focus on header modification use case
+// - Removed deprecated CancelRequest support and request tracking (unused in this codebase)
+
+package notary
+
+import (
+	"net/http"
+)
+
+// headerTransport is a custom RoundTripper that adds headers to requests.
+type headerTransport struct {
+	base    http.RoundTripper
+	headers http.Header
+}
+
+// RoundTrip implements the http.RoundTripper interface.
+// It clones the request, adds headers, and executes the request.
+func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Clone the request to avoid modifying the original
+	req2 := t.cloneRequest(req)
+
+	// Add custom headers
+	for key, values := range t.headers {
+		req2.Header[key] = append(req2.Header[key], values...)
+	}
+
+	// Execute the request
+	return t.base.RoundTrip(req2)
+}
+
+// cloneRequest returns a clone of the provided *http.Request.
+// The clone is a shallow copy of the struct and its Header map.
+func (t *headerTransport) cloneRequest(r *http.Request) *http.Request {
+	// shallow copy of the struct
+	r2 := new(http.Request)
+	*r2 = *r
+	// deep copy of the Header to avoid race conditions
+	r2.Header = make(http.Header, len(r.Header))
+	for k, s := range r.Header {
+		r2.Header[k] = append([]string(nil), s...)
+	}
+	return r2
+}
+
+// Made with Bob

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -15,14 +15,20 @@
 package e2e
 
 import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	testFramework "github.com/IBM/portieris/test/framework"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -40,6 +46,107 @@ const (
 	MutatingWebhookName  = "image-admission-config"
 	AdmissionWebhookName = "image-admission-config"
 )
+
+// validateRegistryCredentials checks if the IBM Cloud Container Registry credentials are valid
+func validateRegistryCredentials(framework *testFramework.Framework) error {
+	log.Println("Validating IBM Cloud Container Registry credentials...")
+
+	// Get the secret from default namespace
+	secretNames := []string{"all-icr-io", "default-icr-io"}
+	var secretData map[string][]byte
+
+	for _, secretName := range secretNames {
+		s, err := framework.KubeClient.CoreV1().Secrets("default").Get(context.TODO(), secretName, metav1.GetOptions{})
+		if err == nil {
+			secretData = s.Data
+			log.Printf("Found secret: %s\n", secretName)
+			break
+		}
+	}
+
+	if secretData == nil {
+		return fmt.Errorf("no IBM Cloud registry secrets found in default namespace (looked for: %v)", secretNames)
+	}
+
+	// Parse the dockerconfigjson
+	dockerConfigJSON, ok := secretData[".dockerconfigjson"]
+	if !ok {
+		return fmt.Errorf("secret does not contain .dockerconfigjson")
+	}
+
+	var dockerConfig struct {
+		Auths map[string]struct {
+			Username string `json:"username"`
+			Password string `json:"password"`
+			Auth     string `json:"auth"`
+		} `json:"auths"`
+	}
+
+	if err := json.Unmarshal(dockerConfigJSON, &dockerConfig); err != nil {
+		return fmt.Errorf("failed to parse dockerconfigjson: %v", err)
+	}
+
+	// Test credentials for each registry
+	validRegistries := 0
+	for registry, creds := range dockerConfig.Auths {
+		// Skip non-ICR registries
+		if !strings.Contains(registry, "icr.io") {
+			continue
+		}
+
+		username := creds.Username
+		password := creds.Password
+
+		// If auth field is present, decode it
+		if creds.Auth != "" {
+			decoded, err := base64.StdEncoding.DecodeString(creds.Auth)
+			if err == nil {
+				parts := strings.SplitN(string(decoded), ":", 2)
+				if len(parts) == 2 {
+					username = parts[0]
+					password = parts[1]
+				}
+			}
+		}
+
+		// Test the credentials by attempting to get a token
+		tokenURL := fmt.Sprintf("https://%s/oauth/token", registry)
+		req, err := http.NewRequest("GET", tokenURL, nil)
+		if err != nil {
+			log.Printf("Warning: failed to create request for %s: %v\n", registry, err)
+			continue
+		}
+
+		req.SetBasicAuth(username, password)
+		req.Header.Set("Service", "registry")
+
+		client := &http.Client{Timeout: 10 * time.Second}
+		resp, err := client.Do(req)
+		if err != nil {
+			log.Printf("Warning: failed to validate credentials for %s: %v\n", registry, err)
+			continue
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusUnauthorized {
+			// 200 = valid credentials, 401 = endpoint exists but creds invalid
+			if resp.StatusCode == http.StatusUnauthorized {
+				return fmt.Errorf("invalid credentials for registry %s (HTTP 401). Please update the secret in the default namespace with valid IBM Cloud API key", registry)
+			}
+			log.Printf("✓ Credentials validated for %s\n", registry)
+			validRegistries++
+		} else {
+			log.Printf("Warning: unexpected response %d from %s\n", resp.StatusCode, registry)
+		}
+	}
+
+	if validRegistries == 0 {
+		return fmt.Errorf("no valid IBM Cloud Container Registry credentials found. Please ensure the secret in default namespace contains valid credentials")
+	}
+
+	log.Printf("Successfully validated credentials for %d registries\n", validRegistries)
+	return nil
+}
 
 func TestMain(m *testing.M) {
 	helmChart := flag.String("helmChart", "", "helm chart location")
@@ -67,6 +174,14 @@ func TestMain(m *testing.M) {
 	framework, err = testFramework.New(os.Getenv("KUBECONFIG"), *helmChart, noInstall)
 	if err != nil {
 		log.Printf("error during framework initialisation: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Validate registry credentials before running tests
+	if err := validateRegistryCredentials(framework); err != nil {
+		log.Printf("ERROR: Registry credential validation failed: %v\n", err)
+		log.Println("Please update the IBM Cloud Container Registry credentials in the 'default' namespace before running tests.")
+		log.Println("This validation prevents test timeouts caused by invalid API keys.")
 		os.Exit(1)
 	}
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018, 2023 Portieris Authors.
+// Copyright 2018, 2026 Portieris Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
- **Release v0.13.38 - Remove deprecated distribution/distribution dependency**
- **Simplify transport.go and add registry credential validation**

Added credential validation as my local tests were failing due to a typo in the local credential.

e2e tests passing:
```
PASS
ok      github.com/IBM/portieris/test/e2e       193.333s
```
