### PR TITLE
increase_qps_and_burst_values

### DIFF
--- a/cmd/portieris/main.go
+++ b/cmd/portieris/main.go
@@ -65,7 +65,8 @@ func main() {
 
 	glog.Info("Starting portieris ", info.Version)
 
-	kubeClientConfig := kube.GetKubeClientConfig(kubeconfig)
+	// Rate limits are read from KUBE_API_QPS / KUBE_API_BURST env vars (injected by Helm)
+	kubeClientConfig := kube.GetKubeClientConfig(kubeconfig, 0, 0)
 	kubeClientset := kube.GetKubeClient(kubeClientConfig)
 	kubeWrapper := kubernetes.NewKubeClientsetWrapper(kubeClientset)
 	policyClient := kube.GetPolicyClient(kubeClientConfig)

--- a/helm/portieris/templates/deployment.yaml
+++ b/helm/portieris/templates/deployment.yaml
@@ -66,6 +66,14 @@ spec:
             initialDelaySeconds: 10
             timeoutSeconds: 10
           env:
+            {{- if .Values.kubeClientRateLimits.qps }}
+            - name: KUBE_API_QPS
+              value: "{{ .Values.kubeClientRateLimits.qps }}"
+            {{- end }}
+            {{- if .Values.kubeClientRateLimits.burst }}
+            - name: KUBE_API_BURST
+              value: "{{ .Values.kubeClientRateLimits.burst }}"
+            {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/helm/portieris/values.yaml
+++ b/helm/portieris/values.yaml
@@ -53,6 +53,14 @@ UseGeneratedCerts:
   tlsKey: |-
   caCert: |-
 
+# Kubernetes API client rate limits.
+# Leave unset to use the client-go defaults (QPS=5, Burst=10)
+# If only one is set, the other is derived automatically using a 2:1 burst-to-QPS ratio
+# Example for a busy ROKS cluster would be qps: 50, burst: 100
+kubeClientRateLimits:
+  qps:
+  burst:
+
 # Resoures defined to assist scheduling
 # request is typical x10, limit is typical x100
 resources:

--- a/helpers/kube/kube.go
+++ b/helpers/kube/kube.go
@@ -17,6 +17,7 @@ package kube
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/IBM/portieris/internal/info"
 	portierisclientset "github.com/IBM/portieris/pkg/apis/portieris.cloud.ibm.com/client/clientset/versioned"
@@ -27,8 +28,9 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// GetKubeClientConfig creates a kube client config
-func GetKubeClientConfig(kubeconfigFileLoc *string) *rest.Config {
+// GetKubeClientConfig creates a kube client config.
+// If KUBE_API_QPS or KUBE_API_BURST are set, they override the client-go defaults (QPS=5, Burst=10).
+func GetKubeClientConfig(kubeconfigFileLoc *string, qps float32, burst int) *rest.Config {
 	var config *rest.Config
 	var err error
 
@@ -62,6 +64,37 @@ func GetKubeClientConfig(kubeconfigFileLoc *string) *rest.Config {
 	}
 
 	config.UserAgent = "portieris/" + info.Version
+
+	if qps == 0 {
+		if v, parseErr := strconv.ParseFloat(os.Getenv("KUBE_API_QPS"), 32); parseErr == nil && v > 0 {
+			qps = float32(v)
+		}
+	}
+	if burst == 0 {
+		if v, atoiErr := strconv.Atoi(os.Getenv("KUBE_API_BURST")); atoiErr == nil && v > 0 {
+			burst = v
+		}
+	}
+
+	if qps > 0 && burst == 0 {
+		burst = int(qps * 2)
+		glog.Warningf("KUBE_API_BURST not set; derived burst=%d from qps=%.1f (2x ratio)", burst, qps)
+	}
+	if burst > 0 && qps == 0 {
+		qps = float32(burst) / 2
+		glog.Warningf("KUBE_API_QPS not set; derived qps=%.1f from burst=%d (2x ratio)", qps, burst)
+	}
+	config.QPS = qps
+	config.Burst = burst
+
+	logQPS, logBurst := config.QPS, config.Burst
+	if logQPS == 0 {
+		logQPS = 5
+	}
+	if logBurst == 0 {
+		logBurst = 10
+	}
+	glog.Infof("kube client rate limits: qps=%.1f burst=%d", logQPS, logBurst)
 
 	return config
 }

--- a/helpers/kube/kube_test.go
+++ b/helpers/kube/kube_test.go
@@ -1,0 +1,172 @@
+// Copyright 2018, 2021 Portieris Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/IBM/portieris/internal/info"
+)
+
+// minimalKubeconfig writes a valid kubeconfig to a temp file and returns its path.
+func minimalKubeconfig(t *testing.T) string {
+	t.Helper()
+	kubeconfigPath := filepath.Join(t.TempDir(), "kubeconfig")
+	kubeconfig := []byte(`
+apiVersion: v1
+kind: Config
+clusters:
+- name: test-cluster
+  cluster:
+    server: https://127.0.0.1
+contexts:
+- name: test-context
+  context:
+    cluster: test-cluster
+    user: test-user
+current-context: test-context
+users:
+- name: test-user
+  user:
+    token: test-token
+`)
+	if err := os.WriteFile(kubeconfigPath, kubeconfig, 0600); err != nil {
+		t.Fatalf("failed to write temporary kubeconfig: %v", err)
+	}
+	return kubeconfigPath
+}
+
+// TestGetKubeClientConfigDefaults checks that zero values leave the config
+// fields unset, letting client-go apply its own defaults.
+func TestGetKubeClientConfigDefaults(t *testing.T) {
+	path := minimalKubeconfig(t)
+	config := GetKubeClientConfig(&path, 0, 0)
+	if config == nil {
+		t.Fatal("GetKubeClientConfig returned nil")
+	}
+	if got, want := config.UserAgent, "portieris/"+info.Version; got != want {
+		t.Errorf("config.UserAgent = %q, want %q", got, want)
+	}
+	if got := config.QPS; got != 0 {
+		t.Errorf("config.QPS = %v, want 0 (zero signals client-go to use its own default of 5)", got)
+	}
+	if got := config.Burst; got != 0 {
+		t.Errorf("config.Burst = %d, want 0 (zero signals client-go to use its own default of 10)", got)
+	}
+}
+
+// TestGetKubeClientConfigExplicitRateLimits checks that both values are applied
+// when provided explicitly.
+func TestGetKubeClientConfigExplicitRateLimits(t *testing.T) {
+	path := minimalKubeconfig(t)
+	config := GetKubeClientConfig(&path, 50, 100)
+	if config == nil {
+		t.Fatal("GetKubeClientConfig returned nil")
+	}
+	if got, want := config.QPS, float32(50); got != want {
+		t.Errorf("config.QPS = %v, want %v", got, want)
+	}
+	if got, want := config.Burst, 100; got != want {
+		t.Errorf("config.Burst = %d, want %d", got, want)
+	}
+}
+
+// TestGetKubeClientConfigQPSOnlyDerivesBurst checks that burst is auto-derived
+// as 2×qps when only qps is set.
+func TestGetKubeClientConfigQPSOnlyDerivesBurst(t *testing.T) {
+	path := minimalKubeconfig(t)
+	config := GetKubeClientConfig(&path, 50, 0)
+	if config == nil {
+		t.Fatal("GetKubeClientConfig returned nil")
+	}
+	if got, want := config.QPS, float32(50); got != want {
+		t.Errorf("config.QPS = %v, want %v", got, want)
+	}
+	if got, want := config.Burst, 100; got != want {
+		t.Errorf("config.Burst = %d, want %d (2x qps)", got, want)
+	}
+}
+
+// TestGetKubeClientConfigBurstOnlyDerivesQPS checks that qps is auto-derived
+// as burst/2 when only burst is set.
+func TestGetKubeClientConfigBurstOnlyDerivesQPS(t *testing.T) {
+	path := minimalKubeconfig(t)
+	config := GetKubeClientConfig(&path, 0, 100)
+	if config == nil {
+		t.Fatal("GetKubeClientConfig returned nil")
+	}
+	if got, want := config.QPS, float32(50); got != want {
+		t.Errorf("config.QPS = %v, want %v (burst/2)", got, want)
+	}
+	if got, want := config.Burst, 100; got != want {
+		t.Errorf("config.Burst = %d, want %d", got, want)
+	}
+}
+
+// TestGetKubeClientConfigEnvVarsBoth checks that KUBE_API_QPS and KUBE_API_BURST
+// env vars are read when arguments are left at zero (the production path).
+func TestGetKubeClientConfigEnvVarsBoth(t *testing.T) {
+	t.Setenv("KUBE_API_QPS", "50")
+	t.Setenv("KUBE_API_BURST", "100")
+	path := minimalKubeconfig(t)
+	config := GetKubeClientConfig(&path, 0, 0)
+	if config == nil {
+		t.Fatal("GetKubeClientConfig returned nil")
+	}
+	if got, want := config.QPS, float32(50); got != want {
+		t.Errorf("config.QPS = %v, want %v", got, want)
+	}
+	if got, want := config.Burst, 100; got != want {
+		t.Errorf("config.Burst = %d, want %d", got, want)
+	}
+}
+
+// TestGetKubeClientConfigEnvVarQPSOnly checks that burst is derived from KUBE_API_QPS
+// when KUBE_API_BURST is absent.
+func TestGetKubeClientConfigEnvVarQPSOnly(t *testing.T) {
+	t.Setenv("KUBE_API_QPS", "50")
+	t.Setenv("KUBE_API_BURST", "")
+	path := minimalKubeconfig(t)
+	config := GetKubeClientConfig(&path, 0, 0)
+	if config == nil {
+		t.Fatal("GetKubeClientConfig returned nil")
+	}
+	if got, want := config.QPS, float32(50); got != want {
+		t.Errorf("config.QPS = %v, want %v", got, want)
+	}
+	if got, want := config.Burst, 100; got != want {
+		t.Errorf("config.Burst = %d, want %d (2x qps)", got, want)
+	}
+}
+
+// TestGetKubeClientConfigEnvVarBurstOnly checks that qps is derived from KUBE_API_BURST
+// when KUBE_API_QPS is absent.
+func TestGetKubeClientConfigEnvVarBurstOnly(t *testing.T) {
+	t.Setenv("KUBE_API_QPS", "")
+	t.Setenv("KUBE_API_BURST", "100")
+	path := minimalKubeconfig(t)
+	config := GetKubeClientConfig(&path, 0, 0)
+	if config == nil {
+		t.Fatal("GetKubeClientConfig returned nil")
+	}
+	if got, want := config.QPS, float32(50); got != want {
+		t.Errorf("config.QPS = %v, want %v (burst/2)", got, want)
+	}
+	if got, want := config.Burst, 100; got != want {
+		t.Errorf("config.Burst = %d, want %d", got, want)
+	}
+}


### PR DESCRIPTION
Increased the Kubernetes client QPS and burst settings to reduce client-side throttling under higher admission request loads.

In our product (Ikigai / IBM Network Inteligence) kafka sends too many requests and start overwhelming portieris.

I also added a simple unit test covering the configured QPS, burst, and user agent.