### PR TITLE
Add explicit permissions block to workflows

### DIFF
--- a/.github/workflows/go-portieris.yaml
+++ b/.github/workflows/go-portieris.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: alltests


### PR DESCRIPTION
Potential fix for [https://github.com/IBM/portieris/security/code-scanning/1](https://github.com/IBM/portieris/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/go-portieris.yaml` at the workflow root (top-level), so it applies to all jobs unless overridden. For this workflow, the minimal and appropriate scope is:

- `contents: read`

This preserves existing functionality (checkout + test execution) while constraining token capabilities. No imports, methods, or dependencies are needed—just YAML key insertion near the top of the file, typically after `on:` and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
