### PR TITLE
fix(deps): bump golang.org/x/crypto to patch CVE-2026-78662, CVE-2026-56855

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/IBM/portieris
 
-go 1.25.7
-
-toolchain go1.25.12
+go 1.26.0
 
 replace (
 	k8s.io/api => k8s.io/api v0.34.1
@@ -23,7 +21,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/theupdateframework/notary v0.7.0
 	go.podman.io/image/v5 v5.41.0
-	golang.org/x/crypto v0.55.0
+	golang.org/x/crypto v0.56.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.34.1
 	k8s.io/apiextensions-apiserver v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -388,8 +388,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
Automated dependency bump to address two disclosed CVEs in `golang.org/x/crypto`.

- **CVEs:** CVE-2026-78662 ([GO-2026-6354](https://pkg.go.dev/vuln/GO-2026-6354)), CVE-2026-56855 ([GO-2026-6355](https://pkg.go.dev/vuln/GO-2026-6355))
- **Severity:** high (denial of service)
- **Package:** `golang.org/x/crypto` v0.55.0 -> v0.56.0

Both advisories are in `golang.org/x/crypto/ssh`: a malicious peer can flood an established or not-yet-established channel with crafted messages, deadlocking the connection. I checked reachability with `go list -deps` on this module (built with the `containers_image_openpgp` tag, matching your Dockerfile) and confirmed the `ssh` subpackage is **not currently imported** by Portieris — only `openpgp/armor` and `openpgp/errors` are, via `pkg/verifier/simple/gpgArmour.go`. So this isn't exploitable in the shipped binary today, but it's a real, public, already-disclosed vulnerability sitting in your declared dependency graph, and this closes it before any future code path picks up the `ssh` package transitively.

Note: `v0.56.0` raises its own `go` directive to `1.26.0` (an upstream `x/crypto` requirement, not a choice I made), so `go get` bumped this repo's `go.mod` from `go 1.25.7` to `go 1.26.0` accordingly. Your Dockerfile already sets `GOTOOLCHAIN=auto`, so the build picks up the newer toolchain automatically; verified locally with `go build -tags containers_image_openpgp ./...` and `go test ./pkg/verifier/... ./helpers/...` (all passing) using an auto-fetched Go 1.26.8 toolchain. If a `go 1.26` floor is unwelcome for other consumers of this module, happy to hold this PR for a future cycle — just say so.

**Not fully remediated by this PR:** [GO-2026-5932](https://pkg.go.dev/vuln/GO-2026-5932) (informational — `golang.org/x/crypto/openpgp` is flagged unmaintained/unsafe-by-design as a whole package, with no fixed version to bump to) is out of scope here. Portieris's only use of that package is `openpgp/armor.Decode` for un-framing an admin-supplied PGP public key before handing the raw bytes to `go.podman.io/image/v5/signature` for actual verification — the deprecated package's own signature-verification code isn't exercised. Worth a future look if you want to drop the dependency on `x/crypto/openpgp/armor` entirely, but that's a separate, non-trivial change from this bump.

Detected by [osv-scanner](https://google.github.io/osv-scanner/), verified by build + test locally.

---
Filed by [Aeon](https://github.com/aeonfun/aeon).
